### PR TITLE
feat(mcp-edit): allow workspace root argument

### DIFF
--- a/crates/mcp-edit/src/main.rs
+++ b/crates/mcp-edit/src/main.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 use mcp_edit::EditServer;
 use rmcp::{ServiceExt, transport::stdio};
-use std::env;
+use std::{env, path::PathBuf};
 use tracing_subscriber::{self, EnvFilter};
 
 /// Run the Edit MCP server over stdio.
+///
+/// The workspace root may be provided as the first command-line argument.
+/// If omitted, the current working directory is used.
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging to stderr without ANSI color codes.
@@ -16,7 +19,10 @@ async fn main() -> Result<()> {
 
     tracing::info!("Starting mcp-edit server");
 
-    let workspace_root = env::current_dir()?;
+    let workspace_root: PathBuf = env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| env::current_dir().expect("failed to get current dir"));
 
     let service = EditServer::new(workspace_root)
         .serve(stdio())


### PR DESCRIPTION
## Summary
- allow passing workspace root as first argument to mcp-edit binary
- document the optional argument

## Testing
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68933951fab8832aacb57e9129bd7fdc