### PR TITLE
feat: add MCP server integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1185,6 +1191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,7 +1266,11 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "ollama-rs",
+ "once_cell",
  "ratatui",
+ "rmcp",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
 ]
@@ -1384,6 +1406,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -1545,12 +1581,14 @@ dependencies = [
  "futures",
  "paste",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -1597,7 +1635,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2347,6 +2385,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2417,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2386,6 +2457,16 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2454,6 +2535,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/ollama-tui-test/Cargo.toml
+++ b/crates/ollama-tui-test/Cargo.toml
@@ -11,3 +11,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 ratatui = "0.29"
 crossterm = "0.29"
+rmcp = { version = "0.4", features = ["transport-child-process", "client"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+once_cell = "1"

--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -1,56 +1,147 @@
-use std::{io::stdout, time::Duration};
+use std::{collections::HashMap, io::stdout, time::Duration};
 
 use clap::Parser;
 use crossterm::{
     event::{self, Event, KeyCode},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use once_cell::sync::Lazy;
 use ollama_rs::{
-    CoordinatorStreamEvent, Ollama,
-    coordinator::Coordinator,
-    generation::chat::ChatMessage,
-    generation::tools::{ToolCall, ToolCallFunction},
+    generation::chat::{request::ChatMessageRequest, ChatMessage},
+    generation::tools::{ToolCall, ToolFunctionInfo, ToolInfo, ToolType},
+    Ollama,
 };
 use ratatui::{
-    Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     widgets::Paragraph,
+    Terminal,
 };
+use rmcp::{
+    model::{CallToolRequestParam, RawContent},
+    service::{RunningService, RoleClient, ServiceExt},
+    transport::TokioChildProcess,
+};
+use rmcp::service::ServerSink;
+use ollama_rs::re_exports::schemars::Schema;
+use serde::Deserialize;
+use tokio::{process::Command, sync::Mutex};
 use tokio_stream::StreamExt;
+use serde_json::Value;
 
-/// Get the weather for a given city (mock implementation)
-#[ollama_rs::function]
-async fn get_weather(city: String) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    Ok(format!(
-        "The weather in {} is sunny with a temperature of 72°F",
-        city
-    ))
+static MCP_TOOLS: Lazy<Mutex<HashMap<String, ServerSink>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+static MCP_TOOL_INFOS: Lazy<Mutex<Vec<ToolInfo>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
+
+#[derive(Deserialize)]
+struct McpConfig {
+    #[serde(rename = "mcpServers")]
+    mcp_servers: HashMap<String, McpServer>,
 }
 
-/// Calculate distance between two cities (mock implementation)
-#[ollama_rs::function]
-async fn calculate_distance(
-    from_city: String,
-    to_city: String,
+#[derive(Deserialize)]
+struct McpServer {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+}
+
+async fn load_mcp_servers(
+    path: &str,
+) -> Result<Vec<RunningService<RoleClient, ()>>, Box<dyn std::error::Error + Send + Sync>> {
+    let data = tokio::fs::read_to_string(path).await?;
+    let config: McpConfig = serde_json::from_str(&data)?;
+    let mut services = Vec::new();
+    for server in config.mcp_servers.values() {
+        let mut cmd = Command::new(&server.command);
+        cmd.args(&server.args);
+        for (k, v) in &server.env {
+            cmd.env(k, v);
+        }
+        let process = TokioChildProcess::new(cmd)?;
+        let service = ().serve(process).await?;
+        let tools = service.list_tools(Default::default()).await?;
+        {
+            let mut map = MCP_TOOLS.lock().await;
+            let mut infos = MCP_TOOL_INFOS.lock().await;
+            for tool in tools.tools {
+                map.insert(tool.name.to_string(), service.peer().clone());
+                let schema: Schema = serde_json::from_value(tool.schema_as_json_value())?;
+                let description = tool.description.clone().unwrap_or_default().to_string();
+                infos.push(ToolInfo {
+                    tool_type: ToolType::Function,
+                    function: ToolFunctionInfo {
+                        name: tool.name.to_string(),
+                        description,
+                        parameters: schema,
+                    },
+                });
+            }
+        }
+        services.push(service);
+    }
+    Ok(services)
+}
+
+async fn call_mcp_tool(
+    name: &str,
+    args: Value,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    Ok(format!(
-        "The distance from {} to {} is approximately 250 miles",
-        from_city, to_city
-    ))
+    let peer = {
+        let map = MCP_TOOLS.lock().await;
+        map.get(name).cloned()
+    }
+    .ok_or_else(|| format!("Tool {name} not found"))?;
+
+    let result = peer
+        .call_tool(CallToolRequestParam {
+            name: name.to_string().into(),
+            arguments: args.as_object().cloned(),
+        })
+        .await?;
+
+    if let Some(content) = result.content {
+        let text = content
+            .into_iter()
+            .filter_map(|c| match c.raw {
+                RawContent::Text(t) => Some(t.text),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(text)
+    } else if let Some(value) = result.structured_content {
+        Ok(value.to_string())
+    } else {
+        Ok(String::new())
+    }
 }
+
 
 #[derive(Parser, Debug)]
 struct Args {
     /// Ollama host URL, e.g. http://localhost:11434
     #[arg(long, default_value = "http://127.0.0.1:11434")]
     host: String,
+    /// Path to MCP configuration JSON
+    #[arg(long)]
+    mcp: Option<String>,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let args = Args::parse();
+
+    let _services = if let Some(path) = &args.mcp {
+        load_mcp_servers(path).await?
+    } else {
+        Vec::new()
+    };
 
     enable_raw_mode()?;
     let mut stdout = stdout();
@@ -72,12 +163,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn run_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     host: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let ollama = Ollama::try_new(host)?;
-    let mut coordinator = Coordinator::new(ollama, "gpt-oss:20b".to_string(), vec![])
-        .add_tool(get_weather)
-        .add_tool(calculate_distance)
-        .debug(false);
+    let tool_infos = { MCP_TOOL_INFOS.lock().await.clone() };
 
     let mut lines: Vec<String> = Vec::new();
     let mut input = String::new();
@@ -119,75 +207,113 @@ async fn run_app<B: ratatui::backend::Backend>(
                         input.clear();
 
                         history.push(ChatMessage::user(query.clone()));
-                        let stream = coordinator.chat_stream(history.clone()).await?;
-                        let mut stream = Box::pin(stream);
                         let mut current_line = String::new();
-
-                        while let Some(event) = stream.next().await {
-                            match event {
-                                CoordinatorStreamEvent::ContentChunk(content) => {
-                                    current_line.push_str(&content);
+                        let mut tool_calls: Vec<ToolCall> = Vec::new();
+                        {
+                            let request = ChatMessageRequest::new(
+                                "gpt-oss:20b".to_string(),
+                                history.clone(),
+                            )
+                            .tools(tool_infos.clone());
+                            let mut stream =
+                                ollama.send_chat_messages_stream(request).await?;
+                            while let Some(chunk) = stream.next().await {
+                                let chunk = match chunk {
+                                    Ok(c) => c,
+                                    Err(_) => break,
+                                };
+                                if !chunk.message.content.is_empty() {
+                                    current_line.push_str(&chunk.message.content);
                                 }
-                                CoordinatorStreamEvent::ToolCallStarted { name, args } => {
-                                    lines.push(current_line.clone());
-                                    if !current_line.is_empty() {
-                                        history.push(ChatMessage::assistant(current_line.clone()));
-                                    }
-                                    let mut call_msg = ChatMessage::assistant(String::new());
-                                    call_msg.tool_calls.push(ToolCall {
-                                        function: ToolCallFunction {
-                                            name: name.clone(),
-                                            arguments: args.clone(),
-                                        },
-                                    });
-                                    history.push(call_msg);
-                                    lines.push(format!(
-                                        "🔧 [Calling tool: {} with args: {}]",
-                                        name, args
-                                    ));
-                                    lines.push("🤖 Assistant: ".to_string());
-                                    current_line.clear();
-                                }
-                                CoordinatorStreamEvent::ToolCallCompleted { name, result } => {
-                                    lines.push(format!("✅ [Tool {} completed: {}]", name, result));
-                                    lines.push("🤖 Assistant: ".to_string());
-                                    history.push(ChatMessage::tool(result.clone(), name.clone()));
-                                    current_line.clear();
-                                }
-                                CoordinatorStreamEvent::FinalContentChunk(content) => {
-                                    current_line.push_str(&content);
-                                }
-                                CoordinatorStreamEvent::Done => {
-                                    lines.push(current_line.clone());
-                                    lines.push("─".repeat(80));
-                                    if !current_line.is_empty() {
-                                        history.push(ChatMessage::assistant(current_line.clone()));
-                                    }
-                                    current_line.clear();
+                                if chunk.done {
+                                    tool_calls = chunk.message.tool_calls.clone();
                                     break;
                                 }
-                                CoordinatorStreamEvent::Error(err) => {
-                                    lines.push(current_line.clone());
-                                    lines.push(format!("❌ [Error: {}]", err));
-                                    lines.push("─".repeat(80));
-                                    current_line.clear();
-                                    break;
-                                }
+                                terminal.draw(|f| {
+                                    let area = f.area();
+                                    let chunks = Layout::default()
+                                        .direction(Direction::Vertical)
+                                        .constraints(
+                                            [Constraint::Min(1), Constraint::Length(3)].as_ref(),
+                                        )
+                                        .split(area);
+                                    let paragraph = Paragraph::new(lines.join("\n"));
+                                    f.render_widget(paragraph, chunks[0]);
+                                    let input_widget =
+                                        Paragraph::new(format!("> {}", input));
+                                    f.render_widget(input_widget, chunks[1]);
+                                })?;
                             }
+                        }
+                        lines.push(current_line.clone());
+                        if !current_line.is_empty() {
+                            history.push(ChatMessage::assistant(current_line.clone()));
+                        }
+                        current_line.clear();
 
-                            terminal.draw(|f| {
-                                let area = f.area();
-                                let chunks = Layout::default()
-                                    .direction(Direction::Vertical)
-                                    .constraints(
-                                        [Constraint::Min(1), Constraint::Length(3)].as_ref(),
-                                    )
-                                    .split(area);
-                                let paragraph = Paragraph::new(lines.join("\n"));
-                                f.render_widget(paragraph, chunks[0]);
-                                let input_widget = Paragraph::new(format!("> {}", input));
-                                f.render_widget(input_widget, chunks[1]);
-                            })?;
+                        if tool_calls.is_empty() {
+                            lines.push("─".repeat(80));
+                        } else {
+                            for call in tool_calls {
+                                lines.push(format!(
+                                    "🔧 [Calling tool: {} with args: {}]",
+                                    call.function.name, call.function.arguments
+                                ));
+                                let result = call_mcp_tool(
+                                    &call.function.name,
+                                    call.function.arguments.clone(),
+                                )
+                                .await?;
+                                lines.push(format!(
+                                    "✅ [Tool {} completed: {}]",
+                                    call.function.name, result
+                                ));
+                                history.push(ChatMessage::tool(
+                                    result.clone(),
+                                    call.function.name.clone(),
+                                ));
+                            }
+                            lines.push("🤖 Assistant: ".to_string());
+                            let mut final_line = String::new();
+                            let request = ChatMessageRequest::new(
+                                "gpt-oss:20b".to_string(),
+                                history.clone(),
+                            )
+                            .tools(tool_infos.clone());
+                            let mut stream =
+                                ollama.send_chat_messages_stream(request).await?;
+                            while let Some(chunk) = stream.next().await {
+                                let chunk = match chunk {
+                                    Ok(c) => c,
+                                    Err(_) => break,
+                                };
+                                if !chunk.message.content.is_empty() {
+                                    final_line.push_str(&chunk.message.content);
+                                }
+                                if chunk.done {
+                                    break;
+                                }
+                                terminal.draw(|f| {
+                                    let area = f.area();
+                                    let chunks = Layout::default()
+                                        .direction(Direction::Vertical)
+                                        .constraints(
+                                            [Constraint::Min(1), Constraint::Length(3)].as_ref(),
+                                        )
+                                        .split(area);
+                                    let paragraph = Paragraph::new(lines.join("\n"));
+                                    f.render_widget(paragraph, chunks[0]);
+                                    let input_widget =
+                                        Paragraph::new(format!("> {}", input));
+                                    f.render_widget(input_widget, chunks[1]);
+                                })?;
+                            }
+                            lines.push(final_line.clone());
+                            if !final_line.is_empty() {
+                                history
+                                    .push(ChatMessage::assistant(final_line.clone()));
+                            }
+                            lines.push("─".repeat(80));
                         }
                     }
                     KeyCode::Esc => break,


### PR DESCRIPTION
## Summary
- load MCP servers from JSON config and track available tools
- proxy arbitrary LLM tool calls to MCP servers
- support `--mcp` CLI option to specify config path

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6893ffdaa918832a82c42494e8613bb8