### PR TITLE
feat: enable thinking mode for ollama tui

### DIFF
--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -214,7 +214,8 @@ async fn run_app<B: ratatui::backend::Backend>(
                                 "gpt-oss:20b".to_string(),
                                 history.clone(),
                             )
-                            .tools(tool_infos.clone());
+                            .tools(tool_infos.clone())
+                            .think(true);
                             let mut stream =
                                 ollama.send_chat_messages_stream(request).await?;
                             while let Some(chunk) = stream.next().await {
@@ -279,7 +280,8 @@ async fn run_app<B: ratatui::backend::Backend>(
                                 "gpt-oss:20b".to_string(),
                                 history.clone(),
                             )
-                            .tools(tool_infos.clone());
+                            .tools(tool_infos.clone())
+                            .think(true);
                             let mut stream =
                                 ollama.send_chat_messages_stream(request).await?;
                             while let Some(chunk) = stream.next().await {


### PR DESCRIPTION
## Summary
- allow thinking models to think before responding in the Ollama TUI

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689421a5ca70832aad8528b1d0028def