### PR TITLE
Handle MCP tool errors gracefully

### DIFF
--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -271,15 +271,27 @@ async fn run_app<B: ratatui::backend::Backend>(
                                     "🔧 [Calling tool: {} with args: {}]",
                                     call.function.name, call.function.arguments
                                 ));
-                                let result = call_mcp_tool(
+                                let result = match call_mcp_tool(
                                     &call.function.name,
                                     call.function.arguments.clone(),
                                 )
-                                .await?;
-                                lines.push(format!(
-                                    "✅ [Tool {} completed: {}]",
-                                    call.function.name, result
-                                ));
+                                .await
+                                {
+                                    Ok(res) => {
+                                        lines.push(format!(
+                                            "✅ [Tool {} completed: {}]",
+                                            call.function.name, res
+                                        ));
+                                        res
+                                    }
+                                    Err(err) => {
+                                        lines.push(format!(
+                                            "❌ [Tool {} failed: {}]",
+                                            call.function.name, err
+                                        ));
+                                        format!("Tool Failed: {}", err)
+                                    }
+                                };
                                 history.push(ChatMessage::tool(
                                     result.clone(),
                                     call.function.name.clone(),


### PR DESCRIPTION
## Summary
- prevent ollama-tui-test from terminating when a MCP tool call errors
- display tool failure in the UI and send `Tool Failed` message back to chat history

## Testing
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_68942ad312fc832a992db53165f10ae5