### PR TITLE
Wrap and scroll history in Ollama TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "textwrap",
  "tokio",
  "tokio-stream",
 ]
@@ -1846,6 +1847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +1944,17 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2160,6 +2178,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/ollama-tui-test/Cargo.toml
+++ b/crates/ollama-tui-test/Cargo.toml
@@ -15,3 +15,4 @@ rmcp = { version = "0.4", features = ["transport-child-process", "client"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 once_cell = "1"
+textwrap = "0.16"


### PR DESCRIPTION
## Summary
- ensure chat history wraps within terminal width
- scroll history to keep latest lines visible and consolidate rendering logic

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68942cfca780832a8289b5f0e204a92f