### PR TITLE
fix(ollama-tui-test): order thinking before assistant

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -12,7 +12,7 @@ Terminal chat interface to Ollama with MCP tool integration.
 - textwrap: wrap chat history.
 
 ## Features, Requirements and Constraints
-- Streams assistant responses and displays incremental "thinking" tokens.
+- Streams assistant responses and displays incremental "thinking" tokens before assistant messages.
 - Loads MCP servers from configuration, exposes their tools, and executes tool calls with error handling.
 - Chat history is wrapped and scrollable with scrollbar and mouse support.
 - Thinking traces, tool calls, and tool results are collapsible.

--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -329,13 +329,13 @@ async fn run_app<B: ratatui::backend::Backend>(
                         input.clear();
                         chat_history.push(ChatMessage::user(query.clone()));
 
-                        loop {
-                            items.push(HistoryItem::Text("🤖 Assistant: ".to_string()));
-                            let assistant_index = items.len() - 1;
-                            let mut current_line = String::new();
-                            let mut current_thinking = String::new();
-                            let mut thinking_index: Option<usize> = None;
-                            let mut tool_calls: Vec<ToolCall> = Vec::new();
+                                loop {
+                                items.push(HistoryItem::Text("🤖 Assistant: ".to_string()));
+                                let mut assistant_index = items.len() - 1;
+                                let mut current_line = String::new();
+                                let mut current_thinking = String::new();
+                                let mut thinking_index: Option<usize> = None;
+                                let mut tool_calls: Vec<ToolCall> = Vec::new();
 
                             let request = ChatMessageRequest::new(
                                 "gpt-oss:20b".to_string(),
@@ -351,11 +351,16 @@ async fn run_app<B: ratatui::backend::Backend>(
                                 };
                                 if let Some(thinking) = chunk.message.thinking.as_ref() {
                                     let idx = thinking_index.unwrap_or_else(|| {
-                                        items.push(HistoryItem::Thinking {
-                                            text: String::new(),
-                                            collapsed: false,
-                                        });
-                                        items.len() - 1
+                                        items.insert(
+                                            assistant_index,
+                                            HistoryItem::Thinking {
+                                                text: String::new(),
+                                                collapsed: false,
+                                            },
+                                        );
+                                        let idx = assistant_index;
+                                        assistant_index += 1;
+                                        idx
                                     });
                                     thinking_index = Some(idx);
                                     current_thinking.push_str(thinking);


### PR DESCRIPTION
## Summary
- ensure thinking entries are inserted before assistant output
- document thinking ordering behavior

## Testing
- `cargo test -p ollama-tui-test`

------
https://chatgpt.com/codex/tasks/task_e_68944680d9c0832a9c15223f016cb2e2