### PR TITLE
fix(ollama-tui-test): render tool outputs as plain text

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -18,3 +18,4 @@ Terminal chat interface to Ollama with MCP tool integration.
 - Thinking traces, tool calls, and tool results are collapsible.
 - Allows specifying the Ollama host via CLI option.
 - User, assistant, and thinking entries render Markdown via `tui-markdown`.
+- Tool call arguments and results render as plain text (no Markdown).


### PR DESCRIPTION
## Summary
- don't run tool call and result entries through the markdown renderer

## Testing
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_689469c1b47c832ab22f41292a52974c