### PR TITLE
feat: streamline thinking display

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -17,5 +17,5 @@ Terminal chat interface to Ollama with MCP tool integration.
 - Chat history is wrapped and scrollable with scrollbar and mouse support.
 - Groups all reasoning and tool steps into a single "Thinking" block that shows "Thinking" while in progress and summarizes as "Thought for …" when complete.
 - Allows specifying the Ollama host via CLI option.
-- User prompts render inside a boxed region with a 5-character left margin; thinking blocks are flush left with wrapped lines indented by two spaces.
-- Tool call arguments and results render as plain text (no Markdown).
+- User prompts render inside a boxed region with a 5-character left margin followed by a blank line; thinking blocks are flush left with wrapped lines indented by two spaces and end with a blank line.
+- Thinking steps start with a bullet; tool names are italicized while tool arguments and results render as plain text.

--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -226,6 +226,9 @@ fn wrap_history_lines(
                 lines.push(format!("     └{}┘", "─".repeat(box_width)));
                 mapping.push(LineMapping::Item(idx));
                 markdown.push(false);
+                lines.push(String::new());
+                mapping.push(LineMapping::Item(idx));
+                markdown.push(false);
             }
             HistoryItem::Assistant(text) => {
                 for w in wrap(text, width.max(1)) {
@@ -284,19 +287,19 @@ fn wrap_history_lines(
                                 collapsed: tc_collapsed,
                             } => {
                                 if *tc_collapsed {
-                                    lines.push(format!("{name} ›"));
+                                    lines.push(format!("· _{name}_ ›"));
                                     mapping.push(LineMapping::Step {
                                         item: idx,
                                         step: s_idx,
                                     });
-                                    markdown.push(false);
+                                    markdown.push(true);
                                 } else {
-                                    lines.push(format!("{name} ⌄"));
+                                    lines.push(format!("· _{name}_ ⌄"));
                                     mapping.push(LineMapping::Step {
                                         item: idx,
                                         step: s_idx,
                                     });
-                                    markdown.push(false);
+                                    markdown.push(true);
                                     for w in wrap(
                                         &format!("args: {args}"),
                                         width.saturating_sub(2).max(1),
@@ -325,6 +328,9 @@ fn wrap_history_lines(
                         }
                     }
                 }
+                lines.push(String::new());
+                mapping.push(LineMapping::Item(idx));
+                markdown.push(false);
             }
             HistoryItem::Separator => {
                 lines.push("─".repeat(width));


### PR DESCRIPTION
## Summary
- group MCP reasoning and tool calls into single collapsible Thinking block
- render user requests inside a boxed region with left margin

## Testing
- `cargo test -p ollama-tui-test`

------
https://chatgpt.com/codex/tasks/task_e_6894726175dc832a88bba84f0b18b404