### PR TITLE
chore: clarify nested bullet depth in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,11 @@ At the end of each task, for the corresponding AGENTS.md files:
 * check that no listed features/requirements/constraints have been accidentally removed or violated.
 * update the list to add/remove/update any features/requirements/constraints involved in this specific task.
 
-The list should always be formatted as brief bullet points. Minor/unimportant details should be omitted.
+The list should always be formatted as brief bullet points with hierarchical structure. Sub-lists may be nested as deeply as necessary. Minor/unimportant details should be omitted. e.g:
+* The textbox allows both prompts and commands
+  * Commands start with a /
+    * Example: `/help` lists commands
+  * Ctrl-D will exit
 
 A template for component-specific AGENTS.md files follows:
 

--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -2,18 +2,33 @@
 MCP server offering file system editing utilities.
 
 ## Dependencies
-- rmcp: build MCP server and tools.
-- serde and schemars: define tool parameter types and schemas.
-- tokio: asynchronous runtime and test framework.
-- base64: encode binary file data.
-- globset, ignore, regex: globbing and pattern search.
-- tracing and tracing-subscriber: logging.
+- rmcp
+  - build MCP server and tools
+- serde
+  - define tool parameter types
+  - uses `schemars` to generate JSON schemas
+- tokio
+  - asynchronous runtime and test framework
+- base64
+  - encode binary file data
+- globset, ignore, regex
+  - globbing and pattern search
+- tracing
+  - logging
+  - uses `tracing-subscriber` for output formatting
 
 ## Features, Requirements and Constraints
-- Workspace root is provided via CLI; all paths must be absolute within this directory.
-- Tools include `replace`, `list_directory`, `read_file`, `write_file`, `glob`, and `search_file_content`.
-- `replace` enforces the expected number of string replacements.
-- `read_file` supports offset/limit and base64-encoded images.
-- `write_file` creates parent directories as needed.
-- `glob` respects git ignore and optional case sensitivity.
-- `search_file_content` runs regex searches with optional include filters.
+- workspace root via CLI
+  - all paths must be absolute within this directory
+- tools
+  - `replace`
+    - enforces the expected number of string replacements
+  - `list_directory`
+  - `read_file`
+    - supports offset/limit and base64-encoded images
+  - `write_file`
+    - creates parent directories as needed
+  - `glob`
+    - respects git ignore and optional case sensitivity
+  - `search_file_content`
+    - runs regex searches with optional include filters

--- a/crates/mcp-hello/AGENTS.md
+++ b/crates/mcp-hello/AGENTS.md
@@ -2,10 +2,17 @@
 Simple MCP server that provides a greeting tool.
 
 ## Dependencies
-- rmcp: implement MCP server and tool definitions.
-- tokio: asynchronous runtime for server and tests.
-- tracing and tracing-subscriber: structured logging.
+- rmcp
+  - implement MCP server and tool definitions
+- tokio
+  - asynchronous runtime for server and tests
+- tracing
+  - structured logging
+  - uses `tracing-subscriber` for output formatting
 
 ## Features, Requirements and Constraints
-- Exposes a `hello` tool returning "Hello, world!".
-- Executable server runs over stdio.
+- tools
+  - `hello`
+    - returns "Hello, world!"
+- server
+  - runs over stdio

--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -2,27 +2,66 @@
 Terminal chat interface to Ollama with MCP tool integration.
 
 ## Dependencies
-- clap: parse command-line arguments.
-- ollama-rs (dstoc fork): communicate with Ollama using streaming and tools.
-- tokio and tokio-stream: asynchronous runtime and streaming.
-- ratatui and crossterm: terminal UI and input handling.
-- rmcp: connect to MCP servers.
-- serde and serde_json: load MCP server configuration.
-- once_cell: shared state for loaded tools.
-- textwrap: wrap chat history.
-- termimad: render markdown.
+- clap
+  - parse command-line arguments
+- ollama-rs (dstoc fork)
+  - communicate with Ollama using streaming and tools
+- tokio
+  - asynchronous runtime
+  - streaming via `tokio-stream`
+- ratatui
+  - terminal UI
+    - input handling via `crossterm`
+- rmcp
+  - connect to MCP servers
+- serde
+  - load MCP server configuration
+    - `serde_json` handles JSON parsing
+- once_cell
+  - shared state for loaded tools
+- textwrap
+  - wrap chat history
+- termimad
+  - render markdown
 
 ## Features, Requirements and Constraints
-- Streams assistant responses and displays incremental "thinking" tokens before assistant messages.
-- Loads MCP servers from configuration, exposes their tools, and executes tool calls with error handling.
-- Chat history is wrapped and scrollable with scrollbar and mouse support.
-- Groups all reasoning and tool steps into a single "Thinking" block that shows "Thinking" while in progress and summarizes as "Thought for …" when complete.
-- Allows specifying the Ollama host via CLI option.
-- User prompts render inside a boxed region with a 5-character left margin followed by a blank line; thinking blocks are flush left with wrapped lines indented by two spaces and end with a blank line.
-- Thinking steps start with a bullet; tool names are italicized while tool arguments and results render as plain text.
-- Markdown rendering via termimad preserves code block indentation and tables with padding and complete Unicode borders and is covered by tests.
-- Markdown rendering maps termimad foreground and background colors to ratatui styles.
-- Block quotes render with a styled quote mark and italic text.
-- Code blocks and tables are centered, with code blocks showing rectangular backgrounds.
-- Markdown skin colors headings with ANSI 178, bold text yellow, and italic text magenta.
-- Blank lines within code blocks retain their background shading without introducing extra unstyled lines, and code block padding uses the base style to keep rectangular backgrounds.
+- assistant responses
+  - stream incrementally
+    - display "thinking" tokens before assistant messages
+- MCP servers
+  - loaded from configuration
+    - expose tools
+    - execute tool calls with error handling
+- chat history
+  - wrapped and scrollable
+    - scrollbar and mouse support
+- reasoning and tool steps
+  - grouped into a single "Thinking" block
+    - shows "Thinking" while in progress
+    - summarizes as "Thought for …" when complete
+- Ollama host
+  - specified via CLI option
+- user prompts
+  - render inside a boxed region
+    - 5-character left margin followed by a blank line
+  - thinking blocks
+    - flush left with wrapped lines indented by two spaces
+    - end with a blank line
+- thinking steps
+  - start with a bullet
+  - tool names italicized
+    - tool arguments and results render as plain text
+- markdown rendering
+  - via termimad
+    - preserves code block indentation and tables with padding and complete Unicode borders
+    - code blocks and tables centered
+      - code blocks show rectangular backgrounds
+      - blank lines retain background shading
+      - padding uses the base style
+    - covered by tests
+  - maps termimad foreground and background colors to ratatui styles
+  - block quotes render with a styled quote mark and italic text
+  - markdown skin
+    - colors headings with ANSI 178
+    - bold text yellow
+    - italic text magenta


### PR DESCRIPTION
## Summary
- allow AGENTS lists to nest bullet points to any depth and illustrate with a three-level example
- restructure crate AGENTS files to use deeper hierarchical lists for dependencies and features

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895432935d0832a8f99d76ba7a5e981