### PR TITLE
feat(mcp-edit): add read_many_files tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1218,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
+ "glob",
  "globset",
  "ignore",
  "regex",

--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -13,6 +13,8 @@ MCP server offering file system editing utilities.
   - encode binary file data
 - globset, ignore, regex
   - globbing and pattern search
+- glob
+  - expand glob patterns for reading many files
 - tracing
   - logging
   - uses `tracing-subscriber` for output formatting
@@ -26,6 +28,8 @@ MCP server offering file system editing utilities.
   - `list_directory`
   - `read_file`
     - supports offset/limit and base64-encoded images
+  - `read_many_files`
+    - reads and concatenates multiple files using glob patterns
   - `write_file`
     - creates parent directories as needed
   - `glob`

--- a/crates/mcp-edit/Cargo.toml
+++ b/crates/mcp-edit/Cargo.toml
@@ -16,6 +16,7 @@ base64 = "0.21"
 globset = "0.4"
 ignore = "0.4"
 regex = "1"
+glob = "0.3.2"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add `read_many_files` tool for globbing and reading multiple files
- document new capability and dependency
- test reading multiple files

## Testing
- `cargo fmt`
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68954d1d3e00832a9b894a5c73645703