### PR TITLE
feat(ollama-tui-test): switch to genai with provider/model options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.3.5"
+version = "0.4.0-alpha.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8957a26f596fad1248e60f6cd4c08eecaf1933168ce92f70a97c0d0773334620"
+checksum = "a1965313b7ff25995e6363b48951421ac3c24e4502559f69d952f327ff9913b1"
 dependencies = [
  "bytes",
  "derive_more 2.0.1",

--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -45,6 +45,7 @@ Terminal chat interface to LLM providers via genai with MCP tool integration.
     - shows "Thinking" while in progress
     - summarizes as "Thought for …" when complete
     - persists across follow-up requests after tool calls
+    - handles streaming tool call chunks as they arrive
 - endpoint
   - specified via CLI option
   - normalized to ensure a trailing `/v1/`

--- a/crates/ollama-tui-test/Cargo.toml
+++ b/crates/ollama-tui-test/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 once_cell = "1"
 textwrap = "0.16"
 termimad = "0.33.0"
-genai = "0.3.5"
+genai = "0.4.0-alpha.11"
 
 [dev-dependencies]
 insta = "1.43.1"


### PR DESCRIPTION
## Summary
- replace `ollama-rs` with `genai` for multi-provider streaming and tool support
- add CLI flags for provider, model, and endpoint
- update event loop to handle `genai` chat stream events and tool calls

## Testing
- `cargo check -p ollama-tui-test`
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_689591530d7c832a824d48f0a0d16d29