### PR TITLE
feat(ollama-tui-test): run tool calls in parallel

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -82,5 +82,8 @@ Terminal chat interface to Ollama with MCP tool integration.
 - main loop
   - handles terminal events and async updates concurrently
   - UI remains interactive while requests stream or tools execute
+  - tool calls may arrive before streaming completes
+    - spawn immediately and run in parallel
+    - after streaming ends, waits for all tool calls before continuing
   - after tool calls complete, sends a follow-up request with results for the final assistant response
     - inserts a new assistant placeholder before streaming the final response


### PR DESCRIPTION
## Summary
- run tool calls concurrently by spawning each as it is received
- wait for all tool calls to finish after streaming completes before sending a follow-up request

## Testing
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_6895d7af9aa4832aa93859b06d917960