### PR TITLE
refactor: expose scroll logic for testing

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -53,6 +53,9 @@ Terminal chat interface to Ollama with MCP tool integration.
 - chat history
   - wrapped and scrollable
     - scrollbar and mouse support
+    - scroll calculations exposed for unit tests
+    - scrollbar hides when history fits viewport
+    - snapshot tests cover top and bottom positions
   - padded to 100 columns and centered
     - user prompt boxes extend to the right edge
 - reasoning and tool steps


### PR DESCRIPTION
## Summary
- clamp scroll state with explicit maximum to keep scrollbar in sync with history
- hide scrollbar when content fits and update snapshots to ensure bottom reaches end

## Testing
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_689744a0ceb8832a8711db989af05569