### PR TITLE
refactor(ollama-tui-test): improve scroll behavior

### DIFF
--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -55,6 +55,9 @@ Terminal chat interface to Ollama with MCP tool integration.
     - scrollbar and mouse support
     - scroll calculations exposed for unit tests
     - scrollbar hides when history fits viewport
+    - clamps to bottom when history fits viewport
+    - auto-scrolls when already at bottom
+    - preserves position when not at bottom
     - snapshot tests cover top and bottom positions
   - padded to 100 columns and centered
     - user prompt boxes extend to the right edge

--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -253,6 +253,7 @@ async fn run_app<B: ratatui::backend::Backend>(
     let mut input = Input::default();
     let mut chat_history: Vec<ChatMessage> = Vec::new();
     let mut scroll_offset: i32 = 0;
+    let mut last_max_scroll: i32 = 0;
     let mut draw_state = DrawState::default();
     let mut events = EventStream::new();
     let mut chat_stream: Option<llm::ChatStream> = None;
@@ -268,7 +269,7 @@ async fn run_app<B: ratatui::backend::Backend>(
 
     loop {
         terminal.draw(|f| {
-            draw_state = draw_ui(f, &items, &input, &mut scroll_offset);
+            draw_state = draw_ui(f, &items, &input, &mut scroll_offset, &mut last_max_scroll);
         })?;
 
         tokio::select! {


### PR DESCRIPTION
## Summary
- clamp short chat history to bottom of viewport
- keep view at bottom when new messages arrive there
- verify scroll position and bottom clamping with new tests
- restore insta snapshot assertions for chat message rendering
- drop trailing blank line so lone user messages are bottom-clamped

## Testing
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_6897540f524c832abc6aeeea4a0f7bcb