### PR TITLE
feat(llm-cli): scaffold tuirealm-based TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ The project is divided into crates:
 * crates/mcp-hello
 * crates/mcp-edit
 * crates/ollama-tui-test
+* crates/llm-cli
 
 # Glossary
 MCP: Model Context Protocol

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
+name = "llm-cli"
+version = "0.1.0"
+dependencies = [
+ "ratatui",
+ "tui-realm-stdlib",
+ "tuirealm",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +2924,42 @@ checksum = "911e93158bf80bbc94bad533b2b16e3d711e1132d69a6a6980c3920a63422c19"
 dependencies = [
  "crossterm 0.29.0",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "tui-realm-stdlib"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c5dd796e9ba2d0d2cfe26dc6a84d5a8287ec110ee1226a53d8cde9a24d67cf"
+dependencies = [
+ "textwrap",
+ "tuirealm",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "tuirealm"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29607ee819f733f15c6bbad6aa760ed3d52b345588130003399bd792bfc6b0a8"
+dependencies = [
+ "bitflags",
+ "crossterm 0.29.0",
+ "lazy-regex",
+ "ratatui",
+ "thiserror 2.0.12",
+ "tuirealm_derive",
+]
+
+[[package]]
+name = "tuirealm_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad3c151090da5a036321776209b3d026df637d7f52c0984ff8d45927326ab4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -1,0 +1,17 @@
+# llm-cli
+Basic terminal chat interface scaffold using tuirealm and ratatui.
+
+## Dependencies
+- ratatui
+  - terminal UI rendering
+- tuirealm
+  - component-based TUI framework
+- tui-realm-stdlib
+  - prebuilt tuirealm components
+
+## Features, Requirements and Constraints
+- layout
+  - scrollable message history pane
+  - text input field at the bottom
+  - Tab switches focus between history and input
+  - Esc exits the application

--- a/crates/llm-cli/Cargo.toml
+++ b/crates/llm-cli/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "llm-cli"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ratatui = "0.29.0"
+tui-realm-stdlib = "3.0.0"
+tuirealm = "3.0.1"

--- a/crates/llm-cli/src/components/history.rs
+++ b/crates/llm-cli/src/components/history.rs
@@ -1,0 +1,59 @@
+use tui_realm_stdlib::Textarea;
+use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::event::{Key, KeyEvent};
+use tuirealm::props::{Alignment, BorderType, Borders, Color, TextSpan};
+use tuirealm::{Component, Event, MockComponent, NoUserEvent};
+
+use crate::Msg;
+
+#[derive(MockComponent)]
+pub struct History {
+    component: Textarea,
+}
+
+impl Default for History {
+    fn default() -> Self {
+        Self {
+            component: Textarea::default()
+                .borders(
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(Color::LightBlue),
+                )
+                .foreground(Color::LightBlue)
+                .title("History", Alignment::Left)
+                .step(4)
+                .text_rows([TextSpan::from("Welcome to llm-cli!")]),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for History {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let _ = match ev {
+            Event::Keyboard(KeyEvent {
+                code: Key::Down, ..
+            }) => self.perform(Cmd::Move(Direction::Down)),
+            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
+                self.perform(Cmd::Move(Direction::Up))
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::PageDown,
+                ..
+            }) => self.perform(Cmd::Scroll(Direction::Down)),
+            Event::Keyboard(KeyEvent {
+                code: Key::PageUp, ..
+            }) => self.perform(Cmd::Scroll(Direction::Up)),
+            Event::Keyboard(KeyEvent {
+                code: Key::Home, ..
+            }) => self.perform(Cmd::GoTo(Position::Begin)),
+            Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
+                self.perform(Cmd::GoTo(Position::End))
+            }
+            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::FocusInput),
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
+            _ => CmdResult::None,
+        };
+        Some(Msg::None)
+    }
+}

--- a/crates/llm-cli/src/components/input.rs
+++ b/crates/llm-cli/src/components/input.rs
@@ -1,0 +1,61 @@
+use tui_realm_stdlib::Input;
+use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::event::{Key, KeyEvent, KeyModifiers};
+use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::{Component, Event, MockComponent, NoUserEvent};
+
+use crate::Msg;
+
+#[derive(MockComponent)]
+pub struct Prompt {
+    component: Input,
+}
+
+impl Default for Prompt {
+    fn default() -> Self {
+        Self {
+            component: Input::default()
+                .borders(
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(Color::LightBlue),
+                )
+                .foreground(Color::LightBlue)
+                .title("Input", Alignment::Left),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for Prompt {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let _ = match ev {
+            Event::Keyboard(KeyEvent {
+                code: Key::Left, ..
+            }) => self.perform(Cmd::Move(Direction::Left)),
+            Event::Keyboard(KeyEvent {
+                code: Key::Right, ..
+            }) => self.perform(Cmd::Move(Direction::Right)),
+            Event::Keyboard(KeyEvent {
+                code: Key::Home, ..
+            }) => self.perform(Cmd::GoTo(Position::Begin)),
+            Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
+                self.perform(Cmd::GoTo(Position::End))
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Delete, ..
+            }) => self.perform(Cmd::Cancel),
+            Event::Keyboard(KeyEvent {
+                code: Key::Backspace,
+                ..
+            }) => self.perform(Cmd::Delete),
+            Event::Keyboard(KeyEvent {
+                code: Key::Char(ch),
+                modifiers: KeyModifiers::NONE,
+            }) => self.perform(Cmd::Type(ch)),
+            Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => return Some(Msg::FocusHistory),
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(Msg::AppClose),
+            _ => CmdResult::None,
+        };
+        Some(Msg::None)
+    }
+}

--- a/crates/llm-cli/src/components/mod.rs
+++ b/crates/llm-cli/src/components/mod.rs
@@ -1,0 +1,5 @@
+pub mod history;
+pub mod input;
+
+pub use history::History;
+pub use input::Prompt;

--- a/crates/llm-cli/src/main.rs
+++ b/crates/llm-cli/src/main.rs
@@ -1,0 +1,113 @@
+use std::time::Duration;
+
+use tuirealm::EventListenerCfg;
+use tuirealm::application::PollStrategy;
+use tuirealm::ratatui::layout::{Constraint, Direction as LayoutDirection, Layout};
+use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
+use tuirealm::{Application, NoUserEvent, Update};
+
+mod components;
+use components::{History, Prompt};
+
+#[derive(Debug, PartialEq)]
+pub enum Msg {
+    AppClose,
+    FocusHistory,
+    FocusInput,
+    None,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub enum Id {
+    History,
+    Input,
+}
+
+struct Model {
+    app: Application<Id, Msg, NoUserEvent>,
+    quit: bool,
+    redraw: bool,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
+            EventListenerCfg::default().crossterm_input_listener(Duration::from_millis(10), 10),
+        );
+        assert!(
+            app.mount(Id::History, Box::new(History::default()), vec![])
+                .is_ok()
+        );
+        assert!(
+            app.mount(Id::Input, Box::new(Prompt::default()), vec![])
+                .is_ok()
+        );
+        assert!(app.active(&Id::Input).is_ok());
+        Self {
+            app,
+            quit: false,
+            redraw: true,
+        }
+    }
+}
+
+impl Model {
+    fn view(&mut self, terminal: &mut TerminalBridge<CrosstermTerminalAdapter>) {
+        let _ = terminal.raw_mut().draw(|f| {
+            let chunks = Layout::default()
+                .direction(LayoutDirection::Vertical)
+                .margin(1)
+                .constraints([Constraint::Min(1), Constraint::Length(3)].as_ref())
+                .split(f.area());
+            self.app.view(&Id::History, f, chunks[0]);
+            self.app.view(&Id::Input, f, chunks[1]);
+        });
+    }
+}
+
+impl Update<Msg> for Model {
+    fn update(&mut self, msg: Option<Msg>) -> Option<Msg> {
+        self.redraw = true;
+        match msg.unwrap_or(Msg::None) {
+            Msg::AppClose => {
+                self.quit = true;
+                None
+            }
+            Msg::FocusHistory => {
+                let _ = self.app.active(&Id::History);
+                None
+            }
+            Msg::FocusInput => {
+                let _ = self.app.active(&Id::Input);
+                None
+            }
+            Msg::None => None,
+        }
+    }
+}
+
+fn main() {
+    let mut model = Model::default();
+    let mut terminal = TerminalBridge::init_crossterm().expect("Cannot create terminal bridge");
+    let _ = terminal.enable_raw_mode();
+    let _ = terminal.enter_alternate_screen();
+
+    while !model.quit {
+        if let Ok(messages) = model.app.tick(PollStrategy::Once) {
+            for msg in messages {
+                let mut current = Some(msg);
+                while let Some(m) = current {
+                    current = model.update(Some(m));
+                }
+            }
+        }
+        if model.redraw {
+            model.view(&mut terminal);
+            model.redraw = false;
+        }
+    }
+
+    let _ = terminal.leave_alternate_screen();
+    let _ = terminal.disable_raw_mode();
+    let _ = terminal.clear_screen();
+}


### PR DESCRIPTION
## Summary
- add new `llm-cli` crate using tuirealm and ratatui
- render scrollable history pane with input field below
- document crate and include in workspace AGENTS

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68985a15a374832a92fba267588c9209