### PR TITLE
feat(llm): centralize tool execution loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "gemini-rs",
  "ollama-rs",
  "serde_json",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -1676,6 +1677,7 @@ dependencies = [
 name = "ollama-tui-test"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "crossterm 0.29.0",
  "insta",

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -23,3 +23,6 @@ Trait-based LLM client implementations for multiple providers.
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
 - Responses
   - chunks include content, tool calls, and optional thinking text
+- Tool orchestration
+  - `tools` module exposes a `ToolExecutor` trait
+  - `run_tool_loop` streams responses, executes tools, and issues follow-up requests

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -10,4 +10,5 @@ async-trait = "0.1.88"
 gemini-rs = { git = "https://github.com/dstoc/gemini-rs", branch = "include-thoughts", version = "2.0.0" }
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
 serde_json = "1.0.142"
+tokio = { version = "1.47.1", features = ["macros", "rt", "sync"] }
 tokio-stream = "0.1.17"

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -16,6 +16,7 @@ pub use ollama_rs::{
 pub mod gemini;
 pub mod ollama;
 pub mod openai;
+pub mod tools;
 
 #[derive(Debug)]
 pub struct ResponseMessage {

--- a/crates/llm/src/tools.rs
+++ b/crates/llm/src/tools.rs
@@ -1,0 +1,176 @@
+use std::{error::Error, sync::Arc};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::{sync::mpsc::UnboundedSender, task::JoinSet};
+use tokio_stream::StreamExt;
+
+use crate::{ChatMessage, ChatMessageRequest, LlmClient, ResponseChunk};
+
+#[async_trait]
+pub trait ToolExecutor: Send + Sync {
+    async fn call(&self, name: &str, args: Value) -> Result<String, Box<dyn Error + Send + Sync>>;
+}
+
+pub enum ToolEvent {
+    Chunk(ResponseChunk),
+    ToolStarted {
+        id: usize,
+        name: String,
+        args: Value,
+    },
+    ToolResult {
+        id: usize,
+        name: String,
+        result: Result<String, Box<dyn Error + Send + Sync>>,
+    },
+}
+
+pub async fn run_tool_loop(
+    client: Arc<dyn LlmClient>,
+    mut request: ChatMessageRequest,
+    tool_executor: Arc<dyn ToolExecutor>,
+    mut chat_history: Vec<ChatMessage>,
+    tx: UnboundedSender<ToolEvent>,
+) -> Result<Vec<ChatMessage>, Box<dyn Error + Send + Sync>> {
+    let mut next_id = 0usize;
+    loop {
+        let mut stream = client.send_chat_messages_stream(request.clone()).await?;
+        let mut handles: JoinSet<(usize, String, Result<String, Box<dyn Error + Send + Sync>>)> =
+            JoinSet::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            let done = chunk.done;
+            let tool_calls = chunk.message.tool_calls.clone();
+            tx.send(ToolEvent::Chunk(chunk)).ok();
+            for call in tool_calls {
+                let id = next_id;
+                next_id += 1;
+                tx.send(ToolEvent::ToolStarted {
+                    id,
+                    name: call.function.name.clone(),
+                    args: call.function.arguments.clone(),
+                })
+                .ok();
+                let executor = tool_executor.clone();
+                let name = call.function.name.clone();
+                let args = call.function.arguments.clone();
+                handles.spawn(async move {
+                    let res = executor.call(&name, args).await;
+                    (id, name, res)
+                });
+            }
+            if done {
+                break;
+            }
+        }
+        if handles.is_empty() {
+            break;
+        }
+        while let Some(res) = handles.join_next().await {
+            if let Ok((id, name, result)) = res {
+                match &result {
+                    Ok(text) => chat_history.push(ChatMessage::tool(text.clone(), name.clone())),
+                    Err(err) => chat_history.push(ChatMessage::tool(
+                        format!("Tool Failed: {}", err),
+                        name.clone(),
+                    )),
+                }
+                tx.send(ToolEvent::ToolResult { id, name, result }).ok();
+            }
+        }
+        request = ChatMessageRequest::new(request.model_name.clone(), chat_history.clone())
+            .tools(request.tools.clone())
+            .think(true);
+    }
+    Ok(chat_history)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::sync::Mutex;
+    use tokio_stream::{self};
+
+    struct DummyClient {
+        calls: Mutex<u32>,
+    }
+
+    #[async_trait]
+    impl LlmClient for DummyClient {
+        async fn send_chat_messages_stream(
+            &self,
+            _request: ChatMessageRequest,
+        ) -> Result<crate::ChatStream, Box<dyn Error + Send + Sync>> {
+            let mut calls = self.calls.lock().unwrap();
+            *calls += 1;
+            let stream: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> = match *calls {
+                1 => vec![Ok(ResponseChunk {
+                    message: crate::ResponseMessage {
+                        content: String::new(),
+                        thinking: None,
+                        tool_calls: vec![crate::ToolCall {
+                            function: crate::ToolCallFunction {
+                                name: "test".into(),
+                                arguments: Value::Null,
+                            },
+                        }],
+                    },
+                    done: true,
+                })],
+                2 => vec![Ok(ResponseChunk {
+                    message: crate::ResponseMessage {
+                        content: "final".into(),
+                        thinking: None,
+                        tool_calls: vec![],
+                    },
+                    done: true,
+                })],
+                _ => vec![],
+            };
+            Ok(Box::pin(tokio_stream::iter(stream)))
+        }
+    }
+
+    struct DummyExecutor;
+
+    #[async_trait]
+    impl ToolExecutor for DummyExecutor {
+        async fn call(
+            &self,
+            name: &str,
+            _args: Value,
+        ) -> Result<String, Box<dyn Error + Send + Sync>> {
+            Ok(format!("called {name}"))
+        }
+    }
+
+    #[tokio::test]
+    async fn executes_tool_and_follow_up() {
+        let client = Arc::new(DummyClient {
+            calls: Mutex::new(0),
+        });
+        let exec = Arc::new(DummyExecutor);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let history = vec![ChatMessage::user("hi".to_string())];
+        let request = ChatMessageRequest::new("m".into(), history.clone()).think(true);
+        let updated = run_tool_loop(client, request, exec, history, tx)
+            .await
+            .unwrap();
+        // ensure tool result added to history
+        assert_eq!(updated.len(), 2);
+        // collect events
+        let mut saw_final = false;
+        let mut saw_tool = false;
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                ToolEvent::ToolResult { .. } => saw_tool = true,
+                ToolEvent::Chunk(c) if c.message.content == "final" => saw_final = true,
+                _ => {}
+            }
+        }
+        assert!(saw_tool);
+        assert!(saw_final);
+    }
+}

--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -104,8 +104,6 @@ Terminal chat interface to Ollama with MCP tool integration.
 - main loop
   - handles terminal events and async updates concurrently
   - UI remains interactive while requests stream or tools execute
-  - tool calls may arrive before streaming completes
-    - spawn immediately and run in parallel
-    - after streaming ends, waits for all tool calls before continuing
-  - after tool calls complete, sends a follow-up request with results for the final assistant response
-    - inserts a new assistant placeholder before streaming the final response
+  - tool orchestration delegated to `llm::tools::run_tool_loop`
+    - uses `ToolExecutor` for MCP calls
+    - emits streamed chunks and tool results via callbacks

--- a/crates/ollama-tui-test/Cargo.toml
+++ b/crates/ollama-tui-test/Cargo.toml
@@ -19,6 +19,7 @@ termimad = "0.33.0"
 tui-input = { version = "0.14.0", default-features = false, features = ["crossterm"] }
 unicode-width = "0.2.0"
 llm = { version = "0.1.0", path = "../llm" }
+async-trait = "0.1.88"
 
 [dev-dependencies]
 insta = "1.43.1"


### PR DESCRIPTION
## Summary
- add `ToolExecutor` trait and `run_tool_loop` helper to llm
- delegate TUI tool calls to shared loop via `McpToolExecutor`
- document tool orchestration in AGENTS

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68994d5d720c832aaec66566fd569929