### PR TITLE
fix(llm): make response content optional

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -22,7 +22,7 @@ Trait-based LLM client implementations for multiple providers.
 - Tool schemas
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
 - Responses
-  - chunks include content, tool calls, and optional thinking text
+  - chunks include optional content, tool calls, and optional thinking text
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -20,7 +20,7 @@ pub mod tools;
 
 #[derive(Debug)]
 pub struct ResponseMessage {
-    pub content: String,
+    pub content: Option<String>,
     pub tool_calls: Vec<ToolCall>,
     pub thinking: Option<String>,
 }

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -30,7 +30,11 @@ impl LlmClient for OllamaClient {
         let mapped = stream.map(|res| match res {
             Ok(r) => Ok(ResponseChunk {
                 message: ResponseMessage {
-                    content: r.message.content,
+                    content: if r.message.content.is_empty() {
+                        None
+                    } else {
+                        Some(r.message.content)
+                    },
                     tool_calls: r.message.tool_calls,
                     thinking: r.message.thinking,
                 },

--- a/crates/ollama-tui-test/src/main.rs
+++ b/crates/ollama-tui-test/src/main.rs
@@ -337,11 +337,13 @@ async fn run_app<B: ratatui::backend::Backend>(
                                     }
                                 }
                             }
-                            if !chunk.message.content.is_empty() {
-                                current_line.push_str(&chunk.message.content);
-                                let assistant_index = ensure_assistant_item(&mut items);
-                                if let HistoryItem::Assistant(line) = &mut items[assistant_index] {
-                                    *line = current_line.clone();
+                            if let Some(content) = chunk.message.content.as_ref() {
+                                if !content.is_empty() {
+                                    current_line.push_str(content);
+                                    let assistant_index = ensure_assistant_item(&mut items);
+                                    if let HistoryItem::Assistant(line) = &mut items[assistant_index] {
+                                        *line = current_line.clone();
+                                    }
                                 }
                             }
                             if chunk.done && pending_tools.is_empty() {


### PR DESCRIPTION
## Summary
- represent streamed content as `Option<String>`
- propagate optional content across OpenAI, Gemini, and Ollama clients
- handle optional content when running tool loops

## Testing
- `cargo test -p llm`
- `cargo test -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_68996330460c832a8acd54fb990dc74d