### PR TITLE
feat(llm,ollama-tui-test): add tool event stream

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -33,6 +33,7 @@ Trait-based LLM client implementations for multiple providers.
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
+  - `tool_event_stream` spawns the loop and yields `ToolEvent`s with a join handle for updated history
   - `mcp` module
     - `load_mcp_servers` starts configured MCP servers and collects tool schemas
     - `McpToolExecutor` implements `ToolExecutor` for MCP calls

--- a/crates/ollama-tui-test/AGENTS.md
+++ b/crates/ollama-tui-test/AGENTS.md
@@ -98,6 +98,6 @@ Terminal chat interface to Ollama with MCP tool integration.
 - main loop
   - handles terminal events and async updates concurrently
   - UI remains interactive while requests stream or tools execute
-  - tool orchestration delegated to `llm::tools::run_tool_loop`
+  - tool orchestration delegated to `llm::tools::tool_event_stream`
     - uses `ToolExecutor` for MCP calls
-    - emits streamed chunks and tool results via callbacks
+    - consumes a stream of `ToolEvent`s while awaiting updated history


### PR DESCRIPTION
## Summary
- add `tool_event_stream` API to spawn tool loop and stream events
- consume `tool_event_stream` in `ollama-tui-test`
- document tool event stream usage

## Testing
- `cargo test -p llm -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_689974a0375c832a9103f77eee4681b1