### PR TITLE
refactor(llm-cli): simplify interaction and remove input wrapping

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -29,38 +29,36 @@ Basic terminal chat interface scaffold using tuirealm and ratatui.
   - `--model` sets the model identifier
   - `--host` configures the LLM host URL
   - `--mcp` loads MCP server configuration
-- layout
-  - scrollable conversation pane
-    - mouse wheel adjusts scroll
-    - mouse clicks or scrolls in the conversation area focus it even when input is active
-  - text input field at the bottom
-    - supports multi-line editing with wrapping
-    - height expands to fit content
-    - Enter submits the message
-    - Ctrl-J inserts a new line
-    - standard shortcuts: Ctrl-W delete previous word, Ctrl-L clears input
-    - paste inserts clipboard text
-    - clicking the field focuses it
-    - cursor hidden when unfocused
-    - trailing spaces do not move the cursor to the next line
-  - Tab switches focus between conversation and input
-  - Esc exits the application
-- conversation items
-  - initialized with empty history
-  - user messages render inside a boxed region
-  - assistant messages show working steps and final response
-    - working and tool sections toggle with Enter or mouse click
-    - final responses render markdown via termimad
-    - streaming updates append thinking text, tool calls, and tool results
-  - items stored as a strongly typed `Node` enum implementing `ConvNode`
-    - selection moves between components, not individual lines
-    - helper methods append items and steps, bumping `content_rev` for caching
-  - partial items are clipped when scrolled
-  - line caches invalidate on width or content changes
-  - clicking items selects them and toggles collapse
-- code structure
-  - conversation resides under `src/conversation` with modules for nodes and mutation helpers
-- tool streaming
-  - drains remaining events after request completes before clearing state
-- MCP integration
+  - layout
+    - scrollable conversation pane
+      - mouse wheel adjusts scroll
+    - text input field at the bottom
+      - supports multi-line editing without wrapping
+      - height expands to fit content
+      - Enter submits the message
+      - Ctrl-J inserts a new line
+      - standard shortcuts: Ctrl-W delete previous word, Ctrl-L clears input
+      - paste inserts clipboard text
+      - clicking the field focuses it
+      - cursor hidden when unfocused
+      - trailing spaces do not move the cursor to the next line
+    - Esc exits the application
+    - conversation pane has no keyboard interaction
+  - conversation items
+    - initialized with empty history
+    - user messages render inside a boxed region
+    - assistant messages show working steps and final response
+      - working and tool sections toggle with mouse click
+      - final responses render markdown via termimad
+      - streaming updates append thinking text, tool calls, and tool results
+    - items stored as a strongly typed `Node` enum implementing `ConvNode`
+      - helper methods append items and steps, bumping `content_rev` for caching
+    - partial items are clipped when scrolled
+    - line caches invalidate on width or content changes
+    - clicking items toggles collapse without selection
+  - code structure
+    - conversation resides under `src/conversation` with modules for nodes and mutation helpers
+  - tool streaming
+    - drains remaining events after request completes before clearing state
+  - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking

--- a/crates/llm-cli/src/main.rs
+++ b/crates/llm-cli/src/main.rs
@@ -48,7 +48,6 @@ struct Args {
 #[derive(Debug, PartialEq)]
 pub enum Msg {
     AppClose,
-    FocusConversation,
     FocusInput,
     Submit(String),
     None,
@@ -212,10 +211,6 @@ impl Update<Msg> for Model {
         match msg.unwrap_or(Msg::None) {
             Msg::AppClose => {
                 self.quit = true;
-                None
-            }
-            Msg::FocusConversation => {
-                let _ = self.app.active(&Id::Conversation);
                 None
             }
             Msg::FocusInput => {


### PR DESCRIPTION
## Summary
- remove conversation focus and selection logic
- drop manual wrapping in prompt input
- clarify llm-cli interaction requirements

## Testing
- `cargo test -p llm-cli`

------
https://chatgpt.com/codex/tasks/task_e_6899c6090684832a9875d9cf3c8620cc