### PR TITLE
refactor(llm-cli): right-align user bubble with rounded block

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -44,13 +44,13 @@ Basic terminal chat interface scaffold using tuirealm and ratatui.
       - trailing spaces do not move the cursor to the next line
     - Esc exits the application
     - conversation pane has no keyboard interaction
-  - conversation items
-    - initialized with empty history
-    - user messages render inside a boxed region
-    - assistant messages show working steps and final response
-      - working and tool sections toggle with mouse click
-      - final responses render markdown via termimad
-      - streaming updates append thinking text, tool calls, and tool results
+    - conversation items
+      - initialized with empty history
+      - user messages render inside a right-aligned rounded block
+      - assistant messages show working steps and final response
+        - working and tool sections toggle with mouse click
+        - final responses render markdown via termimad
+        - streaming updates append thinking text, tool calls, and tool results
     - items stored as a strongly typed `Node` enum implementing `ConvNode`
       - helper methods append items and steps, bumping `content_rev` for caching
     - partial items are clipped when scrolled


### PR DESCRIPTION
## Summary
- right-align user conversation bubbles
- render user bubble using a rounded `Block` instead of manual borders
- document user bubble alignment

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_6899d31c012c832aa31700c8632aca32