### PR TITLE
feat(llm-cli): improve conversation scroll behavior

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -32,6 +32,8 @@ Basic terminal chat interface scaffold using tuirealm and ratatui.
   - layout
     - scrollable conversation pane
       - mouse wheel adjusts scroll
+      - items snap to bottom with blank space above when short
+      - auto-scrolls when at bottom or after user sends a message
     - text input field at the bottom
       - supports multi-line editing without wrapping
       - height expands to fit content

--- a/crates/llm-cli/src/conversation/mutate.rs
+++ b/crates/llm-cli/src/conversation/mutate.rs
@@ -21,18 +21,26 @@ impl Conversation {
     pub fn push_user(&mut self, text: String) {
         self.items.push(Node::User(UserBubble::new(text)));
         self.dirty = true;
+        self.ensure_layout(self.width);
+        self.scroll_to_bottom();
     }
 
     pub fn push_assistant_block(&mut self) {
+        let at_bottom = self.is_at_bottom();
         self.items.push(Node::Assistant(AssistantBlock::new(
             false,
             Vec::new(),
             String::new(),
         )));
         self.dirty = true;
+        self.ensure_layout(self.width);
+        if at_bottom {
+            self.scroll_to_bottom();
+        }
     }
 
     pub fn append_thinking(&mut self, text: &str) {
+        let at_bottom = self.is_at_bottom();
         let block = self.ensure_last_assistant();
         if let Some(Node::Thought(t)) = block.steps.last_mut() {
             t.text.push_str(text);
@@ -44,16 +52,26 @@ impl Conversation {
         }
         block.content_rev += 1;
         self.dirty = true;
+        self.ensure_layout(self.width);
+        if at_bottom {
+            self.scroll_to_bottom();
+        }
     }
 
     pub fn append_response(&mut self, text: &str) {
+        let at_bottom = self.is_at_bottom();
         let block = self.ensure_last_assistant();
         block.response.push_str(text);
         block.content_rev += 1;
         self.dirty = true;
+        self.ensure_layout(self.width);
+        if at_bottom {
+            self.scroll_to_bottom();
+        }
     }
 
     pub fn add_step(&mut self, mut step: Node) -> usize {
+        let at_bottom = self.is_at_bottom();
         match &mut step {
             Node::Thought(t) => t.content_rev += 1,
             Node::Tool(t) => t.content_rev += 1,
@@ -64,10 +82,15 @@ impl Conversation {
         block.content_rev += 1;
         let idx = block.steps.len() - 1;
         self.dirty = true;
+        self.ensure_layout(self.width);
+        if at_bottom {
+            self.scroll_to_bottom();
+        }
         idx
     }
 
     pub fn update_tool_result(&mut self, step_idx: usize, result: String) {
+        let at_bottom = self.is_at_bottom();
         let block = self.ensure_last_assistant();
         if let Some(Node::Tool(ToolStep {
             result: r,
@@ -79,6 +102,10 @@ impl Conversation {
             *content_rev += 1;
             block.content_rev += 1;
             self.dirty = true;
+            self.ensure_layout(self.width);
+            if at_bottom {
+                self.scroll_to_bottom();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- snap conversation items to the bottom with top padding when content is short
- auto-scroll conversation when at bottom or when user sends a message
- document scrolling behavior in AGENTS.md

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_6899d833d300832a8d5eb2d87b531d38