### PR TITLE
feat(llm-cli): style tool step header and indicate failures

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -55,6 +55,8 @@ Basic terminal chat interface scaffold using tuirealm and ratatui.
         - working and tool sections toggle with mouse click
         - final responses render markdown via termimad
         - streaming updates append thinking text, tool calls, and tool results
+        - tool step headers show tool name italic and underlined
+          - failed tools display the name in red
         - header displays status line summarizing assistant progress
           - before response: "Thinking" plus completed tool count and current tool with spinner
           - after response: "Thought for Ns" with completed tool count

--- a/crates/llm-cli/src/conversation/mutate.rs
+++ b/crates/llm-cli/src/conversation/mutate.rs
@@ -92,18 +92,20 @@ impl Conversation {
         idx
     }
 
-    pub fn update_tool_result(&mut self, step_idx: usize, result: String) {
+    pub fn update_tool_result(&mut self, step_idx: usize, result: String, failed: bool) {
         let at_bottom = self.is_at_bottom();
         let block = self.ensure_last_assistant();
         if let Some(Node::Tool(ToolStep {
             result: r,
             done,
+            failed: f,
             content_rev,
             ..
         })) = block.steps.get_mut(step_idx)
         {
             *r = result;
             *done = true;
+            *f = failed;
             *content_rev += 1;
             block.record_activity();
             block.content_rev += 1;

--- a/crates/llm-cli/src/main.rs
+++ b/crates/llm-cli/src/main.rs
@@ -196,8 +196,13 @@ impl Model {
             }
             ToolEvent::ToolResult { id, result, .. } => {
                 if let Some(idx) = self.pending_tools.remove(&id) {
-                    let text = result.unwrap_or_else(|e| format!("Tool Failed: {}", e));
-                    self.conversation.borrow_mut().update_tool_result(idx, text);
+                    let (text, failed) = match result {
+                        Ok(t) => (t, false),
+                        Err(e) => (format!("Tool Failed: {}", e), true),
+                    };
+                    self.conversation
+                        .borrow_mut()
+                        .update_tool_result(idx, text, failed);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- style tool step headers with italic, underline, and red on failure
- track tool failures and pass status to conversation display
- document tool step formatting in llm-cli AGENTS notes

## Testing
- `cargo fmt`
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_6899ea32ddc4832ab931ef373cdd7046