### PR TITLE
fix(mcp-edit): prevent path traversal leaks

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -22,6 +22,7 @@ MCP server offering file system editing utilities.
 ## Features, Requirements and Constraints
 - workspace root via CLI
   - all paths must be absolute within this directory
+  - paths outside the workspace return the same error regardless of file existence
 - tools
   - `replace`
     - enforces the expected number of string replacements


### PR DESCRIPTION
## Summary
- prevent leaking existence of files outside workspace
- test read/write operations on out-of-scope paths

## Testing
- `cargo test -p mcp-edit`

------
https://chatgpt.com/codex/tasks/task_e_689b01d06820832a8cd502a0e4fea50d