### PR TITLE
fix(mcp-edit): validate search and glob results stay within workspace

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -35,8 +35,10 @@ MCP server offering file system editing utilities.
     - creates parent directories as needed
   - `glob`
     - respects git ignore and optional case sensitivity
+    - validates matched paths are within the workspace
   - `search_file_content`
     - runs regex searches with optional include filters
+    - validates matches are within the workspace
 - parameter metadata
   - tool parameters include descriptions and default values via rmcp
   - optional parameters prefix descriptions with "Optional."


### PR DESCRIPTION
## Summary
- ensure `glob` and `search_file_content` only report files under the workspace
- document new safety requirements in AGENTS.md
- test that symlinked files outside the workspace are ignored

## Testing
- `cargo fmt`
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_689b0b8c0448832a86a2f890d613e22c