### PR TITLE
fix(llm-cli): abort pending requests on clear and redo

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -58,8 +58,8 @@ Basic terminal chat interface scaffold using a bespoke component framework built
             - `Up`/`Down` navigate model selection
             - `Tab` completes the highlighted model
         - `/quit` exits the application
-        - `/clear` resets conversation history
-        - `/redo` rolls back the last assistant block, restores the previous user message in the input, and refocuses the prompt for editing
+        - `/clear` resets conversation history and aborts any pending request
+        - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, and aborts any pending request
     - Esc exits the application
     - conversation pane has no keyboard interaction
     - conversation items
@@ -87,5 +87,6 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `App` orchestrates event handling, updates, and rendering via `futures_signals::Mutable`
   - tool streaming
     - drains remaining events after request completes before clearing state
+    - in-flight request tasks tracked in a dedicated `JoinSet` to support cancellation
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking


### PR DESCRIPTION
## Summary
- use a dedicated JoinSet to track in-flight chat requests
- abort pending requests on `/clear` and `/redo`
- document cancellation behavior

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a31983eccc832aa773d1e032d370bd