### PR TITLE
feat(llm-cli): track usage and statusline

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -60,10 +60,13 @@ Basic terminal chat interface scaffold using a bespoke component framework built
           - `/provider` switches LLM backend and optional host
             - host defaults to provider-specific configuration when omitted
         - `/quit` exits the application
-        - `/clear` resets conversation history and aborts any pending request
-        - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, and aborts any pending request
+        - `/clear` resets conversation history, aborts any pending request, and zeroes session and context counters
+        - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, aborts any pending request, and recalculates context tokens
     - Esc exits the application
     - conversation pane has no keyboard interaction
+    - 1-line status area
+      - shows provider and model on the left
+      - right-aligned: `ctx <context_tokens>t, Σ <session_in_tokens>t=> <session_out_tokens>t`
     - conversation items
       - initialized with empty history
       - user messages render inside a right-aligned rounded block
@@ -76,6 +79,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - header displays status line summarizing assistant progress
           - before response: "Thinking" plus completed tool count and current tool with spinner
           - after response: "Thought for Ns" with completed tool count
+        - each assistant block tracks input, output, and total token usage
     - items stored as a strongly typed `Node` enum implementing `ConvNode`
       - helper methods append items and steps, bumping `content_rev` for caching
     - partial items are clipped when scrolled

--- a/crates/llm-cli/src/conversation/assistant_block.rs
+++ b/crates/llm-cli/src/conversation/assistant_block.rs
@@ -24,6 +24,9 @@ pub struct AssistantBlock {
     started: Option<Instant>,
     last_update: Option<Instant>,
     spinner: SpinnerStates,
+    pub(crate) input_tokens: u32,
+    pub(crate) output_tokens: u32,
+    pub(crate) total_tokens: u32,
 }
 
 impl AssistantBlock {
@@ -42,7 +45,16 @@ impl AssistantBlock {
             started: None,
             last_update: None,
             spinner,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
         }
+    }
+
+    pub fn set_usage(&mut self, in_tokens: u32, out_tokens: u32) {
+        self.input_tokens = in_tokens;
+        self.output_tokens = out_tokens;
+        self.total_tokens = in_tokens + out_tokens;
     }
 
     pub(crate) fn record_activity(&mut self) {

--- a/crates/llm-cli/src/conversation/conversation.rs
+++ b/crates/llm-cli/src/conversation/conversation.rs
@@ -1,4 +1,5 @@
 use crossterm::event::{Event, MouseButton, MouseEventKind};
+use llm::Usage;
 use ratatui::{Frame, layout::Rect};
 
 use crate::component::Component;
@@ -268,6 +269,12 @@ impl Conversation {
         }
     }
 
+    pub fn set_usage(&mut self, usage: Usage) {
+        if let Some(Node::Assistant(block)) = self.items.last_mut() {
+            block.set_usage(usage.input_tokens, usage.output_tokens);
+        }
+    }
+
     pub fn redo_last(&mut self) -> Option<String> {
         if matches!(self.items.last(), Some(Node::Assistant(_))) {
             self.items.pop();
@@ -279,5 +286,16 @@ impl Conversation {
             }
         }
         None
+    }
+
+    pub fn context_tokens(&self) -> u32 {
+        self.items
+            .iter()
+            .rev()
+            .find_map(|item| match item {
+                Node::Assistant(block) => Some(block.total_tokens),
+                _ => None,
+            })
+            .unwrap_or(0)
     }
 }

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -25,7 +25,8 @@ Trait-based LLM client implementations for multiple providers.
   - implementations for Ollama, OpenAI, and Gemini
 - Provider selection
   - `Provider` enum lists supported backends
-  - `client_from` builds a client for the given provider
+  - `client_from` builds a client for the given provider and model
+    - stores provider and model names for later retrieval
     - uses provider-specific default host when none is supplied
 - Tool schemas
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats


### PR DESCRIPTION
## Summary
- track input/output tokens per assistant block
- maintain session and context token counters
- render statusline with provider/model left and token usage right-aligned
- expose provider and model name from llm client and update CLI to use them

## Testing
- `cargo fmt`
- `cargo test -p llm-cli`
- `cargo check -p ollama-tui-test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c49481f8832a978e89882691a892