### PR TITLE
fix(llm-cli): retain state on model/provider change

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -57,8 +57,10 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - `/model` offers available models from the connected provider
             - `Up`/`Down` navigate model selection
             - `Tab` completes the highlighted model
+            - switching model aborts in-flight requests without clearing history or resetting token counters
           - `/provider` switches LLM backend and optional host
             - host defaults to provider-specific configuration when omitted
+            - retains conversation history and token counters
         - `/quit` exits the application
         - `/clear` resets conversation history, aborts any pending request, and zeroes session and context counters
         - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, aborts any pending request, and recalculates context tokens

--- a/crates/llm-cli/src/app.rs
+++ b/crates/llm-cli/src/app.rs
@@ -253,12 +253,12 @@ impl Component for App {
                     }
                 }
                 Ok(Update::SetModel(model_name)) => {
+                    self.abort_requests();
                     {
                         let mut client = self.client.lock().unwrap();
                         client.set_model(model_name);
                     }
                     self.model.needs_redraw.set(true);
-                    self.model.needs_update.set(true);
                 }
                 Ok(Update::SetProvider(provider, host)) => {
                     self.abort_requests();
@@ -268,12 +268,7 @@ impl Component for App {
                             let mut guard = self.client.lock().unwrap();
                             *guard = new_client;
                         }
-                        self.session_in_tokens = 0;
-                        self.session_out_tokens = 0;
-                        self.chat_history.clear();
-                        self.conversation.clear();
                         self.model.needs_redraw.set(true);
-                        self.model.needs_update.set(true);
                     }
                 }
                 Ok(Update::Clear) => {


### PR DESCRIPTION
## Summary
- keep session tokens and conversation history when switching models or providers
- document that model and provider changes do not clear session state

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e37f364c832aa24dfb13a32bc995