### PR TITLE
fix: enable pasting in llm-cli prompt input

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -45,6 +45,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - Ctrl-J inserts a new line
       - standard shortcuts: Ctrl-W delete previous word, Ctrl-L clears input
       - paste inserts clipboard text
+      - input starts focused to accept paste
       - clicking the field focuses it
       - cursor hidden when unfocused
       - trailing spaces do not move the cursor to the next line

--- a/crates/llm-cli/src/components/input.rs
+++ b/crates/llm-cli/src/components/input.rs
@@ -38,7 +38,7 @@ impl Prompt {
             model,
             textarea: Self::new_textarea(),
             area: Rect::default(),
-            focused: false,
+            focused: true,
             completion: CompletionPopup {
                 result: None,
                 selected: 0,


### PR DESCRIPTION
## Summary
- default llm-cli prompt input to focused so paste events insert text
- note default focus in llm-cli AGENTS guidelines

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a408317358832a8fb206b0a2649e0c