### PR TITLE
refactor(llm-cli): unify command trait

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -90,6 +90,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - code structure
     - conversation resides under `src/conversation` with modules for nodes and mutation helpers
     - command and parameter popups are separate components under `src/components` used by the prompt input
+    - commands are stateful structs implementing a unified `Command` trait with `update` and `commit`, and `CommandRouter` manages them directly
     - bespoke component framework
       - `Component` trait defines `init`, `handle_event`, `update`, `render`
       - `App` orchestrates event handling, updates, and rendering via `futures_signals::Mutable`

--- a/crates/llm-cli/src/components/input.rs
+++ b/crates/llm-cli/src/components/input.rs
@@ -10,9 +10,7 @@ use ratatui::{
 };
 use tui_textarea::{Input as TaInput, Key as TaKey, TextArea};
 
-use super::completion::{
-    Command, CommandInstance, CommandRouter, CompletionPopup, CompletionResult,
-};
+use super::completion::{Command, CommandRouter, CompletionPopup, CompletionResult};
 
 /// Multiline prompt input backed by [`tui_textarea`].
 pub struct Prompt {


### PR DESCRIPTION
## Summary
- collapse `Command` and `CommandInstance` into a single trait with `update` and `commit`
- simplify `CommandRouter` to manage stateful `Command` objects directly
- merge individual command structs with their instance implementations

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4081150f0832abddc4c81c60f48dc