### PR TITLE
feat(mcp-edit): support relative paths and mount point

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -21,8 +21,11 @@ MCP server offering file system editing utilities.
 
 ## Features, Requirements and Constraints
 - workspace root via CLI
-  - all paths must be absolute within this directory
+  - paths may be absolute or relative to this directory
   - paths outside the workspace return the same error regardless of file existence
+- mount point hides actual workspace path in responses
+  - defaults to `/home/user/workspace`
+  - error messages include mount point paths for missing or invalid files
 - tools
   - `replace`
     - enforces the expected number of string replacements
@@ -34,7 +37,8 @@ MCP server offering file system editing utilities.
   - `write_file`
     - creates parent directories as needed
   - `glob`
-    - respects git ignore and optional case sensitivity
+    - always respects git ignore
+    - optional case sensitivity
     - validates matched paths are within the workspace
   - `search_file_content`
     - uses `grep` crate for regex searches with optional include filters


### PR DESCRIPTION
## Summary
- allow relative paths for file operations
- replace workspace prefix in responses using configurable mount point
- always respect .gitignore rules
- sanitize error messages to show mount point paths
- add coverage for path-related errors

## Testing
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68a43efcd268832ab09351bbb9404bfb