### PR TITLE
feat(llm): handle reasoning content in OpenAI client

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -33,6 +33,8 @@ Trait-based LLM client implementations for multiple providers.
 - Responses
   - chunks include optional content, tool calls, optional thinking text, and usage metrics on the final chunk
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
+  - OpenAI client parses `reasoning_content` from streamed responses into thinking text
+  - deprecated `function_call` streaming is no longer supported
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-async-openai = "0.29.0"
+async-openai = { version = "0.29.0", features = ["byot"] }
 async-trait = "0.1.88"
 clap = { version = "4.5.43", features = ["derive"] }
 gemini-rs = { git = "https://github.com/dstoc/gemini-rs", branch = "include-thoughts", version = "2.0.0" }


### PR DESCRIPTION
## Summary
- parse streaming reasoning_content into thinking text
- drop deprecated function_call handling
- enable BYOT in async-openai dependency

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68a479ca97c0832abbaf7f56d1d2a62c