### PR TITLE
fix(llm-cli): prefix wrapped assistant lines

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -79,6 +79,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - working and tool sections toggle with mouse click
         - final responses render markdown via termimad
         - streaming updates append thinking text, tool calls, and tool results
+        - wrapped lines prefix continuation lines with `│`
         - tool step headers show tool name italic and underlined
           - failed tools display the name in red
         - header displays status line summarizing assistant progress

--- a/crates/llm-cli/src/conversation/conversation.rs
+++ b/crates/llm-cli/src/conversation/conversation.rs
@@ -402,8 +402,8 @@ mod tests {
             .join("\n");
         assert_snapshot!(dbg, @r"[Reset,Reset]Thinking ⠋ ⌄
 [Reset,Reset]· word1 word2 word3
-[Reset,Reset]  word4 word5 word6
-[Reset,Reset]  word7 word8 word9
-[Reset,Reset]  word10 word11");
+[Reset,Reset]│ word4 word5 word6
+[Reset,Reset]│ word7 word8 word9
+[Reset,Reset]│ word10 word11");
     }
 }

--- a/crates/llm-cli/src/conversation/thought_step.rs
+++ b/crates/llm-cli/src/conversation/thought_step.rs
@@ -41,7 +41,7 @@ impl ThoughtStep {
             if i == 0 {
                 lines.push(format!("· {}", w));
             } else {
-                lines.push(format!("  {}", w));
+                lines.push(format!("│ {}", w));
             }
         }
         self.lines = lines;

--- a/crates/llm-cli/src/conversation/tool_step.rs
+++ b/crates/llm-cli/src/conversation/tool_step.rs
@@ -61,17 +61,17 @@ impl ToolStep {
             let a_wrap = wrap(&self.args, width.saturating_sub(8) as usize);
             for (i, w) in a_wrap.into_iter().enumerate() {
                 if i == 0 {
-                    lines.push(Line::from(format!("  args: {}", w)));
+                    lines.push(Line::from(format!("│ args: {}", w)));
                 } else {
-                    lines.push(Line::from(format!("        {}", w)));
+                    lines.push(Line::from(format!("│       {}", w)));
                 }
             }
             let r_wrap = wrap(&self.result, width.saturating_sub(10) as usize);
             for (i, w) in r_wrap.into_iter().enumerate() {
                 if i == 0 {
-                    lines.push(Line::from(format!("  result: {}", w)));
+                    lines.push(Line::from(format!("│ result: {}", w)));
                 } else {
-                    lines.push(Line::from(format!("          {}", w)));
+                    lines.push(Line::from(format!("│         {}", w)));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Prefix wrapped assistant lines with thin box drawing character `│` for clearer multi-line steps
- Update snapshot and documentation for new formatting

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a6f3ca9984832a904a4e0ddb9cdf24