### PR TITLE
feat(llm-cli): track conversation state

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -74,6 +74,10 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - right-aligned: `ctx <context_tokens>t, Σ <session_in_tokens>t=> <session_out_tokens>t`
     - conversation state tracking
       - states: idle, thinking, calling tool, responding
+      - thinking chunks switch to thinking state
+      - content chunks switch to responding state
+      - tool start switches to calling tool state
+      - history, error, or clear updates reset to idle
     - conversation items
       - initialized with empty history
       - user messages render inside a right-aligned rounded block

--- a/crates/llm-cli/src/app.rs
+++ b/crates/llm-cli/src/app.rs
@@ -136,13 +136,15 @@ impl App {
     fn handle_tool_event(&mut self, ev: ToolEvent) {
         match ev {
             ToolEvent::Chunk(chunk) => {
-                self.state = ConversationState::Responding;
-                self.model.needs_redraw.set(true);
                 if let Some(thinking) = chunk.message.thinking.as_ref() {
+                    self.state = ConversationState::Thinking;
+                    self.model.needs_redraw.set(true);
                     self.conversation.append_thinking(thinking);
                 }
                 if let Some(content) = chunk.message.content.as_ref() {
                     if !content.is_empty() {
+                        self.state = ConversationState::Responding;
+                        self.model.needs_redraw.set(true);
                         self.conversation.append_response(content);
                     }
                 }
@@ -152,8 +154,6 @@ impl App {
                         self.session_out_tokens += usage.output_tokens;
                         self.conversation.set_usage(usage);
                     }
-                    self.state = ConversationState::Thinking;
-                    self.model.needs_redraw.set(true);
                 }
             }
             ToolEvent::ToolStarted { id, name, args } => {
@@ -173,8 +173,6 @@ impl App {
                     Err(e) => (format!("Tool Failed: {}", e), true),
                 };
                 self.conversation.update_tool_result(id, text, failed);
-                self.state = ConversationState::Thinking;
-                self.model.needs_redraw.set(true);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a conversation state machine to `App`
- surface conversation state in status bar
- document state tracking in AGENTS.md

## Testing
- `cargo fmt`
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a70aecb91c832a8de33098fdffe9f3