### PR TITLE
refactor(llm-cli): use tokio watch for app signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,12 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,22 +855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-signals"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70abe9c40a0dccd69bf7c59ba58714ebeb6c15a88143a10c6be7130e895f1696"
-dependencies = [
- "discard",
- "futures-channel",
- "futures-core",
- "futures-util",
- "gensym",
- "log",
- "pin-project",
- "serde",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,18 +903,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
-]
-
-[[package]]
-name = "gensym"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
 ]
 
 [[package]]
@@ -1568,7 +1534,6 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "futures",
- "futures-signals",
  "insta",
  "llm",
  "ratatui",
@@ -1910,26 +1875,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -2953,6 +2898,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3202,17 +3148,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
-dependencies = [
- "getrandom 0.3.3",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"

--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -6,7 +6,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - terminal UI rendering
 - crossterm
   - terminal events and screen management
-- futures-signals
+- tokio::sync::watch
   - reactive flags for redraw, updates, and quitting
 - textwrap
   - wrap conversation lines
@@ -102,7 +102,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - command and parameter popups are separate components under `src/components` used by the prompt input
     - bespoke component framework
       - `Component` trait defines `init`, `handle_event`, `update`, `render`
-      - `App` orchestrates event handling, updates, and rendering via `futures_signals::Mutable`
+      - `App` orchestrates event handling, updates, and rendering via `tokio::sync::watch` channels
   - tool streaming
     - drains remaining events after request completes before clearing state
     - in-flight request tasks tracked in a dedicated `JoinSet` to support cancellation

--- a/crates/llm-cli/Cargo.toml
+++ b/crates/llm-cli/Cargo.toml
@@ -13,11 +13,10 @@ tui-textarea = "0.7.0"
 unicode-width = "0.2.0"
 llm = { path = "../llm" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 futures = "0.3"
 clap = { version = "4.5.43", features = ["derive"] }
 tui-realm-stdlib = "2.0.1"
-futures-signals = "0.3.34"
 
 [dev-dependencies]
 insta = "1.43.1"


### PR DESCRIPTION
## Summary
- replace futures-signals Mutable flags with tokio::sync::watch channels
- wire WatchStream into event loop for redraw, update, and quit signals
- drop futures-signals dependency and document watch-based design
- use `Arc<AtomicBool>` for prompt component's internal update flag
- internalize prompt submission watch channel within prompt component

## Testing
- `cargo test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a7e7bad654832a8d0211381a6be93a