### PR TITLE
feat(llm): share chat history via Arc mutex

### DIFF
--- a/crates/llm-cli/AGENTS.md
+++ b/crates/llm-cli/AGENTS.md
@@ -106,5 +106,6 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - tool streaming
     - drains remaining events after request completes before clearing state
     - in-flight request tasks tracked in a dedicated `JoinSet` to support cancellation
+    - chat history stored in an `Arc<Mutex<_>>` and shared with the tool loop
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -38,6 +38,8 @@ Trait-based LLM client implementations for multiple providers.
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
+    - shared chat history stored in an `Arc<Mutex<_>>`
+      - chosen over a callback for simplicity and synchronization
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s with a join handle for updated history
   - `mcp` module
     - `load_mcp_servers` starts configured MCP servers and collects tool schemas

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::error::Error;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use tokio_stream::iter;
@@ -97,9 +97,10 @@ mod tests {
         }]);
         let exec = Arc::new(DummyExec);
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let history = vec![ChatMessage::user("hi".into())];
-        let request = ChatMessageRequest::new("m".into(), history.clone()).think(true);
-        let updated = run_tool_loop(client.clone(), request, exec, history, tx)
+        let history = Arc::new(Mutex::new(vec![ChatMessage::user("hi".into())]));
+        let request =
+            ChatMessageRequest::new("m".into(), history.lock().unwrap().clone()).think(true);
+        let updated = run_tool_loop(client.clone(), request, exec, history.clone(), tx)
             .await
             .unwrap();
         let requests = client.requests.lock().unwrap();


### PR DESCRIPTION
## Summary
- share chat history with the tool loop via `Arc<Mutex<Vec<ChatMessage>>>`
- update CLI to use shared chat history
- document rationale for mutex-based history over callbacks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f9977a14832ab43362985a6854f7