### PR TITLE
refactor(llm): define local LLM types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "gemini-rs",
  "ollama-rs",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -18,6 +18,8 @@ Trait-based LLM client implementations for multiple providers.
   - connect to Gemini models
 - rmcp
   - connect to MCP servers
+- schemars
+  - define and manipulate tool schemas
 
 ## Features, Requirements and Constraints
 - LLM clients
@@ -30,6 +32,9 @@ Trait-based LLM client implementations for multiple providers.
     - uses provider-specific default host when none is supplied
 - Tool schemas
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
+- Core message and tool types defined locally instead of re-exporting from `ollama-rs`
+  - tool calls hold name and arguments directly
+  - tool info stores name, description, and parameters without wrapper enums
 - Responses
   - chunks include optional content, tool calls, optional thinking text, and usage metrics on the final chunk
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.5.43", features = ["derive"] }
 gemini-rs = { git = "https://github.com/dstoc/gemini-rs", branch = "include-thoughts", version = "2.0.0" }
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
 rmcp = { version = "0.4.0", features = ["client", "transport-child-process"] }
+schemars = "1.0.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 tokio = { version = "1.47.1", features = ["fs", "macros", "process", "rt", "sync"] }

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -13,7 +13,7 @@ use tokio_stream::StreamExt;
 
 use super::{
     ChatMessageRequest, ChatStream, LlmClient, MessageRole, ResponseChunk, ResponseMessage,
-    ToolCall, ToolCallFunction, Usage, to_openapi_schema,
+    ToolCall, Usage, to_openapi_schema,
 };
 
 pub struct GeminiClient {
@@ -52,8 +52,8 @@ impl LlmClient for GeminiClient {
                             .map(|tool_call| Part {
                                 function_call: Some(FunctionCall {
                                     id: None,
-                                    name: tool_call.function.name.clone(),
-                                    args: tool_call.function.arguments.clone(),
+                                    name: tool_call.name.clone(),
+                                    args: tool_call.arguments.clone(),
                                 }),
                                 ..Default::default()
                             })
@@ -102,9 +102,9 @@ impl LlmClient for GeminiClient {
                 .tools
                 .iter()
                 .map(|t| FunctionDeclaration {
-                    name: t.function.name.clone(),
-                    description: t.function.description.clone(),
-                    parameters: to_openapi_schema(&t.function.parameters),
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: to_openapi_schema(&t.parameters),
                 })
                 .collect();
 
@@ -144,10 +144,8 @@ impl LlmClient for GeminiClient {
                         for part in &candidate.content.parts {
                             if let Some(fc) = &part.function_call {
                                 tool_calls.push(ToolCall {
-                                    function: ToolCallFunction {
-                                        name: fc.name.clone(),
-                                        arguments: fc.args.clone(),
-                                    },
+                                    name: fc.name.clone(),
+                                    arguments: fc.args.clone(),
                                 });
                             } else if let Some(text) = &part.text {
                                 if part.thought == Some(true) {

--- a/crates/llm/src/mcp.rs
+++ b/crates/llm/src/mcp.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio::process::Command;
 
-use crate::{Schema, ToolFunctionInfo, ToolInfo, ToolType, tools::ToolExecutor};
+use crate::{Schema, ToolInfo, tools::ToolExecutor};
 
 #[derive(Default)]
 pub struct McpContext {
@@ -58,12 +58,9 @@ pub async fn load_mcp_servers(
                 let schema: Schema = serde_json::from_value(tool.schema_as_json_value())?;
                 let description = tool.description.clone().unwrap_or_default().to_string();
                 ctx.tool_infos.push(ToolInfo {
-                    tool_type: ToolType::Function,
-                    function: ToolFunctionInfo {
-                        name: tool.name.to_string(),
-                        description,
-                        parameters: schema,
-                    },
+                    name: tool.name.to_string(),
+                    description,
+                    parameters: schema,
                 });
             }
         }

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -52,7 +52,7 @@ impl LlmClient for TestProvider {
 mod tests {
     use super::*;
     use crate::tools::{ToolExecutor, run_tool_loop};
-    use crate::{ChatMessage, MessageRole, ResponseMessage, ToolCall, ToolCallFunction};
+    use crate::{ChatMessage, MessageRole, ResponseMessage, ToolCall};
     use serde_json::Value;
     use std::sync::Arc;
 
@@ -76,10 +76,8 @@ mod tests {
             message: ResponseMessage {
                 content: None,
                 tool_calls: vec![ToolCall {
-                    function: ToolCallFunction {
-                        name: "test".into(),
-                        arguments: Value::Null,
-                    },
+                    name: "test".into(),
+                    arguments: Value::Null,
                 }],
                 thinking: None,
             },

--- a/crates/llm/src/tools.rs
+++ b/crates/llm/src/tools.rs
@@ -97,13 +97,13 @@ pub async fn run_tool_loop(
                 next_id += 1;
                 tx.send(ToolEvent::ToolStarted {
                     id,
-                    name: call.function.name.clone(),
-                    args: call.function.arguments.clone(),
+                    name: call.name.clone(),
+                    args: call.arguments.clone(),
                 })
                 .ok();
                 let executor = tool_executor.clone();
-                let name = call.function.name.clone();
-                let args = call.function.arguments.clone();
+                let name = call.name.clone();
+                let args = call.arguments.clone();
                 handles.spawn(async move {
                     let res = executor.call(&name, args).await;
                     (id, name, res)
@@ -166,10 +166,8 @@ mod tests {
                         content: None,
                         thinking: None,
                         tool_calls: vec![crate::ToolCall {
-                            function: crate::ToolCallFunction {
-                                name: "test".into(),
-                                arguments: Value::Null,
-                            },
+                            name: "test".into(),
+                            arguments: Value::Null,
                         }],
                     },
                     done: true,
@@ -224,7 +222,7 @@ mod tests {
         let call_msg = &updated[1];
         assert_eq!(call_msg.role, MessageRole::Assistant);
         assert_eq!(call_msg.tool_calls.len(), 1);
-        assert_eq!(call_msg.tool_calls[0].function.name, "test");
+        assert_eq!(call_msg.tool_calls[0].name, "test");
         assert!(call_msg.content.is_empty());
         let final_msg = updated.last().unwrap();
         assert_eq!(final_msg.role, MessageRole::Assistant);


### PR DESCRIPTION
## Summary
- add in-crate definitions for messages, tools, and requests instead of re-exporting from `ollama_rs`
- flatten tool call and tool info types to remove nested function structs and the tool-type enum
- convert custom types to provider-specific equivalents in each LLM client

## Testing
- `cargo test -p llm`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a803f71780832aa4e43d1fafb1ab6e