### PR TITLE
fix: share chat history with tool stream

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -46,7 +46,8 @@ Trait-based LLM client implementations for multiple providers.
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
-  - `tool_event_stream` spawns the loop and yields `ToolEvent`s with a join handle for updated history
+  - `tool_event_stream` spawns the loop and yields `ToolEvent`s
+    - join handle resolves on completion with history updated in place
   - `mcp` module
     - `load_mcp_servers` starts configured MCP servers and collects tool schemas
     - `McpToolExecutor` implements `ToolExecutor` for MCP calls


### PR DESCRIPTION
## Summary
- pass shared chat history vector to `tool_event_stream`
- update `tool_event_stream` and `run_tool_loop` to mutate history directly
- adjust tests for new shared-history behavior

## Testing
- `cargo +nightly test -p llm`
- `cargo +nightly test -p llm-cli`


------
https://chatgpt.com/codex/tasks/task_e_68abdb14e344832ab37280529c18a637