### PR TITLE
fix(mcp-shell): add tool parameter descriptions

### DIFF
--- a/crates/mcp-shell/AGENTS.md
+++ b/crates/mcp-shell/AGENTS.md
@@ -41,3 +41,6 @@ MCP server exposing shell command execution.
 - timed-out commands keep running until waited or terminated
   - subsequent run calls error with "command already running"
 - announces available tools to clients via MCP `list_tools`
+- parameter metadata
+  - tool parameters include descriptions and default values via rmcp
+  - optional parameters prefix descriptions with "Optional."

--- a/crates/mcp-shell/src/lib.rs
+++ b/crates/mcp-shell/src/lib.rs
@@ -255,16 +255,24 @@ fn spawn_command(
 
 #[derive(Deserialize, JsonSchema)]
 pub struct RunParams {
+    /// Command to execute.
     command: String,
-    stdin: Option<String>,
+    /// Optional. Text to send to stdin.
     #[serde(default)]
+    #[schemars(default)]
+    stdin: Option<String>,
+    /// Optional. Working directory for the command. Defaults to the workspace directory.
+    #[serde(default)]
+    #[schemars(default)]
     workdir: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
+/// Parameters for the `wait` tool.
 pub struct WaitParams {}
 
 #[derive(Deserialize, JsonSchema)]
+/// Parameters for the `terminate` tool.
 pub struct TerminateParams {}
 
 #[derive(Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
## Summary
- document run, wait, and terminate tool parameters in mcp-shell
- record parameter metadata expectations in AGENTS
- clarify that workdir defaults to the workspace directory

## Testing
- `cargo test -p mcp-shell`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b8b6e90832a940dea77973ff099