### PR TITLE
feat(llm, llment): prefix MCP tool names with server key

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -48,10 +48,11 @@ Trait-based LLM client implementations for multiple providers.
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s
     - join handle resolves on completion with history updated in place
-  - `mcp` module
-    - `load_mcp_servers` starts configured MCP servers and collects tool schemas
-    - `McpToolExecutor` implements `ToolExecutor` for MCP calls
-    - `McpContext` stores MCP tool mappings and metadata
+- `mcp` module
+  - `load_mcp_servers` starts configured MCP servers and collects tool schemas
+    - tool names are prefixed with the server name
+  - `McpToolExecutor` implements `ToolExecutor` for MCP calls
+  - `McpContext` stores MCP tool mappings and metadata
       - tool call chunks insert assistant messages immediately before execution
       - accumulated streamed content is appended as an assistant message after the stream completes
       - contexts can be merged to combine tools and metadata

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -108,6 +108,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - in-flight request tasks tracked in a dedicated `JoinSet` to support cancellation
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking
+  - MCP tool names are prefixed with the server name
   - built-in tools registered in a separate context returned by `setup_builtin_tools`
     - `setup_builtin_tools` returns the context and a running service handle
     - `App` retains service handles to keep MCP transports alive


### PR DESCRIPTION
## Summary
- prefix MCP server tool names with their server key when loading
- strip server prefix before invoking MCP tools
- document prefixed MCP tool names in llm and llment crates

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aea905cc10832aa6fc295a7ef1f7cf