### PR TITLE
feat(llment): make host argument optional

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -31,7 +31,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 - CLI arguments
   - `--provider` selects LLM backend
   - `--model` sets the model identifier
-  - `--host` configures the LLM host URL
+  - `--host` optionally configures the LLM host URL; provider default used when omitted
   - `--mcp` loads MCP server configuration
   - layout
     - scrollable conversation pane

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -84,7 +84,8 @@ impl App {
         let mcp_context = Arc::new(McpContext::default());
         let tool_executor: Arc<dyn ToolExecutor> =
             Arc::new(McpToolExecutor::new(mcp_context.clone()));
-        let client = llm::client_from(args.provider, args.model.clone(), Some(&args.host)).unwrap();
+        let client =
+            llm::client_from(args.provider, args.model.clone(), args.host.as_deref()).unwrap();
         let client = Arc::new(Mutex::new(client));
         let tasks = JoinSet::new();
         let request_tasks = JoinSet::new();

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -37,9 +37,9 @@ pub struct Args {
     /// Model identifier to use
     #[arg(long, default_value = "gpt-oss:20b")]
     model: String,
-    /// LLM host URL, e.g. http://localhost:11434 for Ollama
-    #[arg(long, default_value = "http://localhost:8000/v1")]
-    host: String,
+    /// Optional LLM host URL, e.g. http://localhost:11434 for Ollama
+    #[arg(long)]
+    host: Option<String>,
     /// Path to MCP configuration JSON
     #[arg(long)]
     mcp: Option<String>,


### PR DESCRIPTION
## Summary
- allow `--host` argument to be omitted and pass provider default

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68af9fbe3248832a9b26e281e9593af5