### PR TITLE
feat(llm): add LlamaServer provider with local default host

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -24,12 +24,13 @@ Trait-based LLM client implementations for multiple providers.
 ## Features, Requirements and Constraints
 - LLM clients
   - `LlmClient` trait streams chat responses and lists supported model names
-  - implementations for Ollama, OpenAI, and Gemini
+  - implementations for Ollama, OpenAI, LlamaServer, and Gemini
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model
     - stores provider and model names for later retrieval
     - uses provider-specific default host when none is supplied
+      - LlamaServer defaults to `http://localhost:8000/v1` and wraps the OpenAI client
 - Tool schemas
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
 - Core message and tool types defined locally instead of re-exporting from `ollama-rs`

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -123,6 +123,7 @@ pub enum Provider {
     #[default]
     Ollama,
     Openai,
+    LlamaServer,
     Gemini,
 }
 
@@ -169,6 +170,9 @@ pub fn client_from(
     let inner: Arc<dyn LlmClient> = match provider {
         Provider::Ollama => Arc::new(ollama::OllamaClient::new(host)?),
         Provider::Openai => Arc::new(openai::OpenAiClient::new(host)),
+        Provider::LlamaServer => Arc::new(openai::OpenAiClient::new(Some(
+            host.unwrap_or("http://localhost:8000/v1"),
+        ))),
         Provider::Gemini => Arc::new(gemini::GeminiClient::new(host)),
     };
     Ok(Client {


### PR DESCRIPTION
## Summary
- add `LlamaServer` provider that wraps OpenAI with a localhost default host
- document the new provider and its default host

## Testing
- `cargo test -p llm`
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68afa4a4dd70832a8c6fe1c63bc4abc0