### PR TITLE
fix(llment): default to LlamaServer

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -30,6 +30,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 ## Features, Requirements and Constraints
 - CLI arguments
   - `--provider` selects LLM backend
+    - defaults to LlamaServer when omitted
   - `--model` sets the model identifier
   - `--host` optionally configures the LLM host URL; provider default used when omitted
   - `--mcp` loads MCP server configuration

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -32,7 +32,7 @@ use llm::{self, Provider};
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[arg(long, value_enum, default_value_t = Provider::Openai)]
+    #[arg(long, value_enum, default_value_t = Provider::LlamaServer)]
     provider: Provider,
     /// Model identifier to use
     #[arg(long, default_value = "gpt-oss:20b")]


### PR DESCRIPTION
## Summary
- default provider changed to `LlamaServer`
- document default provider in llment crate AGENTS notes

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68afa9f6df04832a9df41a0fa8f3e4b8