### PR TITLE
refactor(mcp-edit): rename write_file to create_file

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -35,7 +35,7 @@ MCP server offering file system editing utilities.
     - supports offset/limit and base64-encoded images
   - `read_many_files`
     - reads and concatenates multiple files using glob patterns
-  - `write_file`
+  - `create_file`
     - creates parent directories as needed
     - errors if file already exists
   - `glob`


### PR DESCRIPTION
## Summary
- rename write_file tool to create_file for clarity
- update tests and docs accordingly

## Testing
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68afad2f5104832a87a62160003ab5f3