### PR TITLE
feat(mcp-edit): add --allow-modification flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ The mcp-edit server provides a set of file system tools similar to [gemini-cli](
 > [!WARNING]
 > By default, mcp-edit provides read-only access to the current working directory.
 
-Pass `--allow-modification` to enable file modification tools.
-
 ```
 Usage: mcp-edit [OPTIONS] [WORKSPACE_ROOT] [MOUNT_POINT]
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ No other "mcp.json" options or features beyond those used above are currently su
 The mcp-edit server provides a set of file system tools similar to [gemini-cli](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/file-system.md).
 
 > [!WARNING]
-> By default, mcp-server will provide access to the current working directory.
+> By default, mcp-edit provides read-only access to the current working directory.
+
+Pass `--allow-modification` to enable file modification tools.
 
 ```
 Usage: mcp-edit [OPTIONS] [WORKSPACE_ROOT] [MOUNT_POINT]
@@ -80,8 +82,9 @@ Arguments:
   [MOUNT_POINT]     Mount point path used in responses (default: `/home/user/workspace`) [default: /home/user/workspace]
 
 Options:
-      --trace  Show trace
-  -h, --help   Print help
+      --trace               Show trace
+      --allow-modification  Enable file modification tools
+  -h, --help                Print help
 ```
 
 ### mcp-shell

--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -26,6 +26,8 @@ MCP server offering file system editing utilities.
 - mount point hides actual workspace path in responses
   - defaults to `/home/user/workspace`
   - error messages include mount point paths for missing or invalid files
+- file modification tools disabled unless `--allow-modification` flag is passed
+  - modification functions assert they are enabled
 - tools
   - `replace`
     - enforces the expected number of string replacements

--- a/crates/mcp-edit/src/main.rs
+++ b/crates/mcp-edit/src/main.rs
@@ -22,13 +22,14 @@ async fn main() -> Result<()> {
 
     tracing::info!("Starting mcp-edit server");
 
-    let service = FsServer::new_with_mount_point(args.workspace_root, args.mount_point)
-        .serve(stdio())
-        .await
-        .map_err(|e| {
-            tracing::error!("serving error: {:?}", e);
-            e
-        })?;
+    let mut server = FsServer::new_with_mount_point(args.workspace_root, args.mount_point);
+    if !args.allow_modification {
+        server.disable_modification_tools();
+    }
+    let service = server.serve(stdio()).await.map_err(|e| {
+        tracing::error!("serving error: {:?}", e);
+        e
+    })?;
 
     service.waiting().await?;
     Ok(())
@@ -47,4 +48,8 @@ struct Args {
     /// Show trace
     #[arg(long)]
     trace: bool,
+
+    /// Allow tools that modify files
+    #[arg(long)]
+    allow_modification: bool,
 }


### PR DESCRIPTION
## Summary
- add `--allow-modification` flag
- disable file modification tools when flag is absent
- document new flag in README
- assert modification tools are enabled in file-modifying functions

## Testing
- `cargo fmt`
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68afd890ae1c832aa7341bac3400c06e