### PR TITLE
feat: refresh MCP tools on list_changed notifications

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -52,8 +52,9 @@ Trait-based LLM client implementations for multiple providers.
 - `mcp` module
   - `load_mcp_servers` starts configured MCP servers and collects tool schemas
     - tool names are prefixed with the server name
+    - listens for `notifications/tools/list_changed` to refresh tools at runtime
   - `McpToolExecutor` implements `ToolExecutor` for MCP calls
-  - `McpContext` stores MCP tool mappings and metadata
+  - `McpContext` stores MCP tool mappings and metadata behind a `RwLock`
       - tool call chunks insert assistant messages immediately before execution
       - accumulated streamed content is appended as an assistant message after the stream completes
       - contexts can be merged to combine tools and metadata

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -112,6 +112,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking
   - MCP tool names are prefixed with the server name
+  - tool lists refresh automatically when servers send `notifications/tools/list_changed`
   - built-in tools registered in a separate context returned by `setup_builtin_tools`
     - `setup_builtin_tools` returns the context and a running service handle
     - `App` retains service handles to keep MCP transports alive


### PR DESCRIPTION
## Summary
- listen for `notifications/tools/list_changed` and update MCP tool registry
- wrap `McpContext` in `RwLock` and refresh tool metadata in place
- wire `llment` to propagate MCP tool updates without restart

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68afe0b0ca14832a90b11c74f919a41c