### PR TITLE
refactor: unify MCP state in context

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -56,7 +56,6 @@ Trait-based LLM client implementations for multiple providers.
     - implements `ToolExecutor` for MCP calls
     - tool call chunks insert assistant messages immediately before execution
     - accumulated streamed content is appended as an assistant message after the stream completes
-    - contexts can be merged to combine services
 - Test utilities
   - `TestProvider` implements `LlmClient`
     - captures `ChatMessageRequest`s for assertions

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -52,11 +52,11 @@ Trait-based LLM client implementations for multiple providers.
 - `mcp` module
   - `load_mcp_servers` starts configured MCP servers and collects tool schemas
     - tool names are prefixed with the server name
-  - `McpToolExecutor` implements `ToolExecutor` for MCP calls
-  - `McpContext` stores MCP tool mappings and metadata
-      - tool call chunks insert assistant messages immediately before execution
-      - accumulated streamed content is appended as an assistant message after the stream completes
-      - contexts can be merged to combine tools and metadata
+  - `McpContext` stores running services and tool metadata keyed by prefix
+    - implements `ToolExecutor` for MCP calls
+    - tool call chunks insert assistant messages immediately before execution
+    - accumulated streamed content is appended as an assistant message after the stream completes
+    - contexts can be merged to combine services
 - Test utilities
   - `TestProvider` implements `LlmClient`
     - captures `ChatMessageRequest`s for assertions

--- a/crates/llm/src/mcp.rs
+++ b/crates/llm/src/mcp.rs
@@ -27,10 +27,6 @@ impl McpContext {
         self.services.insert(service.prefix.clone(), service);
     }
 
-    pub fn merge(&mut self, other: McpContext) {
-        self.services.extend(other.services.into_iter());
-    }
-
     pub fn tool_infos(&self) -> Vec<ToolInfo> {
         let mut infos = Vec::new();
         for svc in self.services.values() {

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -111,8 +111,8 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - in-flight request tasks tracked in a dedicated `JoinSet` to support cancellation
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking
-  - MCP tool names are prefixed with the server name
-  - built-in tools registered in a separate context returned by `setup_builtin_tools`
-    - `setup_builtin_tools` returns the context and a running service handle
-    - `App` retains service handles to keep MCP transports alive
+  - MCP tool names are prefixed with the server name; built-in tools use the `chat` prefix
+  - built-in tools registered via `setup_builtin_tools`
+    - `setup_builtin_tools` returns an `McpService` inserted into the shared `McpContext`
+    - `McpContext` retains running service handles
     - `get_message_count` returns the number of chat messages

--- a/crates/llment/src/builtins.rs
+++ b/crates/llment/src/builtins.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
-use llm::{ChatMessage, ToolInfo, mcp::McpContext};
+use llm::{ChatMessage, ToolInfo, mcp::McpService};
 use rmcp::{
     ServerHandler,
     handler::server::router::tool::ToolRouter,
     model::{ServerCapabilities, ServerInfo},
-    service::{RoleClient, RunningService, ServiceExt},
+    service::ServiceExt,
     tool, tool_handler, tool_router,
 };
 use schemars::{JsonSchema, schema_for};
@@ -49,9 +49,7 @@ impl ServerHandler for BuiltinTools {
     }
 }
 
-pub async fn setup_builtin_tools(
-    chat_history: Arc<Mutex<Vec<ChatMessage>>>,
-) -> (McpContext, RunningService<RoleClient, ()>) {
+pub async fn setup_builtin_tools(chat_history: Arc<Mutex<Vec<ChatMessage>>>) -> McpService {
     let builtins = BuiltinTools::new(chat_history);
     let (server_transport, client_transport) = duplex(64);
     let (server_res, client_res) = tokio::join!(
@@ -63,14 +61,13 @@ pub async fn setup_builtin_tools(
     tokio::spawn(async move {
         let _ = server.waiting().await;
     });
-    let mut mcp_context = McpContext::default();
-    mcp_context
-        .tools
-        .insert("get_message_count".into(), client_service.peer().clone());
-    mcp_context.tool_infos.push(ToolInfo {
-        name: "get_message_count".into(),
-        description: "Returns the number of chat messages".into(),
-        parameters: schema_for!(GetMessageCountParams),
-    });
-    (mcp_context, client_service)
+    McpService {
+        prefix: "chat".into(),
+        tools: vec![ToolInfo {
+            name: "get_message_count".into(),
+            description: "Returns the number of chat messages".into(),
+            parameters: schema_for!(GetMessageCountParams),
+        }],
+        service: client_service,
+    }
 }

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -81,10 +81,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn run(args: Args) -> Result<(), Box<dyn Error>> {
-    let (mcp_ctx, services) = if let Some(path) = &args.mcp {
+    let mcp_ctx = if let Some(path) = &args.mcp {
         load_mcp_servers(path).await.expect("mcp")
     } else {
-        (McpContext::default(), Vec::new())
+        McpContext::default()
     };
 
     let _guard = TerminalGuard::new()?;
@@ -105,7 +105,7 @@ async fn run(args: Args) -> Result<(), Box<dyn Error>> {
         },
         args,
     );
-    app.init(mcp_ctx, services).await;
+    app.init(mcp_ctx).await;
     Component::init(&mut app);
 
     tokio::spawn(event_loop(tx));


### PR DESCRIPTION
## Summary
- centralize MCP services and tool metadata inside `McpContext`
- expose builtin chat tools through a `McpService` with the `chat` prefix
- simplify app wiring to use `McpContext` directly for tool execution

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b01fa6ba30832a940875dedcd9aabe