### PR TITLE
feat(llm): refresh MCP tool info on updates

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -52,7 +52,10 @@ Trait-based LLM client implementations for multiple providers.
 - `mcp` module
   - `load_mcp_servers` starts configured MCP servers and collects tool schemas
     - tool names are prefixed with the server name
-  - `McpContext` stores running services and tool metadata keyed by prefix
+  - `McpService` implements `ClientHandler`
+    - `on_tool_list_changed` refreshes tool metadata from the service
+  - `McpContext` stores running service handles keyed by prefix
+    - exposes merged `tool_infos` from all services
     - implements `ToolExecutor` for MCP calls
     - tool call chunks insert assistant messages immediately before execution
     - accumulated streamed content is appended as an assistant message after the stream completes

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -112,7 +112,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - MCP integration
   - `ChatMessageRequest` includes MCP `tool_infos` before enabling thinking
   - MCP tool names are prefixed with the server name; built-in tools use the `chat` prefix
-  - built-in tools registered via `setup_builtin_tools`
-    - `setup_builtin_tools` returns an `McpService` inserted into the shared `McpContext`
+- built-in tools registered via `setup_builtin_tools`
+    - `setup_builtin_tools` returns a running `McpService` inserted into the shared `McpContext`
     - `McpContext` retains running service handles
     - `get_message_count` returns the number of chat messages


### PR DESCRIPTION
## Summary
- refresh MCP tool metadata when servers report tool list changes
- track running MCP services directly and expose merged tool infos
- return running MCP service from builtin tool setup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b024894f94832a878a677e6ca7107b