### PR TITLE
refactor(llment): organize commands into modules

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -110,6 +110,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - code structure
     - conversation resides under `src/conversation` with modules for nodes and mutation helpers
     - command and parameter popups are separate components under `src/components` used by the prompt input
+    - app commands live in `src/commands` with one module per command
   - bespoke component framework
       - `Component` trait defines `init`, `handle_event`, `update`, `render`
       - `App` orchestrates event handling, updates, and rendering via `tokio::sync::watch` channels

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -111,6 +111,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - conversation resides under `src/conversation` with modules for nodes and mutation helpers
     - command and parameter popups are separate components under `src/components` used by the prompt input
     - app commands live in `src/commands` with one module per command
+      - `/prompt` embeds prompt assets and exposes a `load_prompt` helper
   - bespoke component framework
       - `Component` trait defines `init`, `handle_event`, `update`, `render`
       - `App` orchestrates event handling, updates, and rendering via `tokio::sync::watch` channels

--- a/crates/llment/src/commands/clear.rs
+++ b/crates/llment/src/commands/clear.rs
@@ -1,0 +1,45 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct ClearCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for ClearCommand {
+    fn name(&self) -> &'static str {
+        "clear"
+    }
+    fn description(&self) -> &'static str {
+        "Clear the conversation history"
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ClearCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+        })
+    }
+}
+
+struct ClearCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+}
+
+impl CommandInstance for ClearCommandInstance {
+    fn update(&mut self, _input: &str) -> CompletionResult {
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.update_tx.send(Update::Clear);
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -1,0 +1,13 @@
+pub mod clear;
+pub mod model;
+pub mod prompt;
+pub mod provider;
+pub mod quit;
+pub mod redo;
+
+pub use clear::ClearCommand;
+pub use model::ModelCommand;
+pub use prompt::PromptCommand;
+pub use provider::ProviderCommand;
+pub use quit::QuitCommand;
+pub use redo::RedoCommand;

--- a/crates/llment/src/commands/model.rs
+++ b/crates/llment/src/commands/model.rs
@@ -1,0 +1,99 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{OnceCell, mpsc::UnboundedSender, oneshot};
+
+use llm::LlmClient;
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, Completion, CompletionResult},
+};
+
+pub struct ModelCommand {
+    pub(crate) client: Arc<Mutex<llm::Client>>,
+    pub(crate) tx: UnboundedSender<Update>,
+}
+
+impl Command for ModelCommand {
+    fn name(&self) -> &'static str {
+        "model"
+    }
+    fn description(&self) -> &'static str {
+        "Change the active model"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ModelCommandInstance {
+            tx: self.tx.clone(),
+            client: self.client.clone(),
+            models: Arc::default(),
+            param: String::default(),
+        })
+    }
+}
+
+struct ModelCommandInstance {
+    tx: UnboundedSender<Update>,
+    client: Arc<Mutex<llm::Client>>,
+    models: Arc<OnceCell<Vec<String>>>,
+    param: String,
+}
+
+impl ModelCommandInstance {
+    fn matching(&self) -> Vec<Completion> {
+        if let Some(models) = self.models.get() {
+            let param = self.param.as_str();
+            models
+                .iter()
+                .filter(|model| model.starts_with(param))
+                .map(|model| Completion {
+                    name: model.clone(),
+                    description: "".to_string(),
+                    str: model.clone(),
+                })
+                .collect()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl CommandInstance for ModelCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        let param = input.trim();
+        self.param = param.to_string();
+        if self.models.get().is_some() {
+            let options = self.matching();
+            CompletionResult::Options { at: 0, options }
+        } else {
+            let client_handle = self.client.clone();
+            let models = self.models.clone();
+            let (tx, rx) = oneshot::channel();
+            tokio::spawn(async move {
+                let client = { client_handle.lock().unwrap().clone() };
+                let _ = models
+                    .get_or_init(|| async move {
+                        match client.list_models().await {
+                            Ok(models) => models,
+                            Err(_) => Vec::new(), // TODO: surface an error?
+                        }
+                    })
+                    .await;
+
+                let _ = tx.send(());
+            });
+            CompletionResult::Loading { at: 0, done: rx }
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.param.is_empty() {
+            Err("no param".into())
+        } else {
+            println!("commit model??");
+            let _ = self.tx.send(Update::SetModel(self.param.clone()));
+            Ok(())
+        }
+    }
+}

--- a/crates/llment/src/commands/prompt.rs
+++ b/crates/llment/src/commands/prompt.rs
@@ -10,17 +10,17 @@ use crate::{
 
 #[derive(RustEmbed)]
 #[folder = "prompts"]
-pub(crate) struct PromptAssets;
+struct PromptAssets;
 
 #[cfg(test)]
 #[derive(RustEmbed)]
 #[folder = "tests/prompts"]
-pub(crate) struct TestPromptAssets;
+struct TestPromptAssets;
 
 #[cfg(test)]
-pub(crate) type Assets = TestPromptAssets;
+type Assets = TestPromptAssets;
 #[cfg(not(test))]
-pub(crate) type Assets = PromptAssets;
+type Assets = PromptAssets;
 
 pub(crate) fn load_prompt(name: &str) -> Option<String> {
     let mut env = Environment::new();

--- a/crates/llment/src/commands/prompt.rs
+++ b/crates/llment/src/commands/prompt.rs
@@ -1,0 +1,81 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::{Assets, Update},
+    components::completion::{Command, CommandInstance, Completion, CompletionResult},
+};
+
+pub struct PromptCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for PromptCommand {
+    fn name(&self) -> &'static str {
+        "prompt"
+    }
+    fn description(&self) -> &'static str {
+        "Load a system prompt"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(PromptCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+            param: String::new(),
+        })
+    }
+}
+
+struct PromptCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+    param: String,
+}
+
+impl PromptCommandInstance {
+    fn prompt_options(&self, typed: &str) -> Vec<Completion> {
+        let mut names: Vec<String> = Assets::iter()
+            .filter_map(|f| {
+                let name = f.as_ref();
+                let name = name
+                    .strip_suffix(".md")
+                    .or_else(|| name.strip_suffix(".md.jinja"))?;
+                if name.starts_with(typed) {
+                    Some(name.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+            .into_iter()
+            .map(|name| Completion {
+                str: name.clone(),
+                description: String::new(),
+                name,
+            })
+            .collect()
+    }
+}
+
+impl CommandInstance for PromptCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        self.param = input.trim().to_string();
+        let options = self.prompt_options(self.param.as_str());
+        CompletionResult::Options { at: 0, options }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.param.is_empty() {
+            Err("no prompt".into())
+        } else {
+            let _ = self.update_tx.send(Update::SetPrompt(self.param.clone()));
+            let _ = self.needs_update.send(true);
+            Ok(())
+        }
+    }
+}

--- a/crates/llment/src/commands/provider.rs
+++ b/crates/llment/src/commands/provider.rs
@@ -1,0 +1,89 @@
+use clap::ValueEnum;
+use llm::Provider;
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, Completion, CompletionResult},
+};
+
+pub struct ProviderCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for ProviderCommand {
+    fn name(&self) -> &'static str {
+        "provider"
+    }
+    fn description(&self) -> &'static str {
+        "Change the active provider"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ProviderCommandInstance {
+            needs_update: self.needs_update.clone(),
+            tx: self.update_tx.clone(),
+            param: String::new(),
+        })
+    }
+}
+
+struct ProviderCommandInstance {
+    needs_update: watch::Sender<bool>,
+    tx: UnboundedSender<Update>,
+    param: String,
+}
+
+impl ProviderCommandInstance {
+    fn provider_options(&self, typed: &str) -> Vec<Completion> {
+        Provider::value_variants()
+            .iter()
+            .filter_map(|p| {
+                let name = p.to_possible_value()?.get_name().to_string();
+                if name.starts_with(typed) {
+                    Some(Completion {
+                        name: name.clone(),
+                        description: String::new(),
+                        str: format!("{} ", name),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl CommandInstance for ProviderCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        self.param = input.trim().to_string();
+        let (prov, host_opt) = match self.param.split_once(' ') {
+            Some((p, h)) => (p, Some(h)),
+            None => (self.param.as_str(), None),
+        };
+        if host_opt.is_none() {
+            let options = self.provider_options(prov);
+            CompletionResult::Options { at: 0, options }
+        } else {
+            CompletionResult::Options {
+                at: 0,
+                options: vec![],
+            }
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.param.is_empty() {
+            return Err("no provider".into());
+        }
+        let mut parts = self.param.split_whitespace();
+        let prov_str = parts.next().ok_or("no provider")?;
+        let provider = Provider::from_str(prov_str, true)?;
+        let host = parts.next().map(|s| s.to_string());
+        let _ = self.tx.send(Update::SetProvider(provider, host));
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/commands/quit.rs
+++ b/crates/llment/src/commands/quit.rs
@@ -1,0 +1,38 @@
+use tokio::sync::watch;
+
+use crate::components::completion::{Command, CommandInstance, CompletionResult};
+
+pub struct QuitCommand {
+    pub(crate) should_quit: watch::Sender<bool>,
+}
+
+impl Command for QuitCommand {
+    fn name(&self) -> &'static str {
+        "quit"
+    }
+    fn description(&self) -> &'static str {
+        "Exit the application"
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(QuitCommandInstance {
+            should_quit: self.should_quit.clone(),
+        })
+    }
+}
+
+struct QuitCommandInstance {
+    should_quit: watch::Sender<bool>,
+}
+
+impl CommandInstance for QuitCommandInstance {
+    fn update(&mut self, _input: &str) -> CompletionResult {
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.should_quit.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/commands/redo.rs
+++ b/crates/llment/src/commands/redo.rs
@@ -1,0 +1,45 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct RedoCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for RedoCommand {
+    fn name(&self) -> &'static str {
+        "redo"
+    }
+    fn description(&self) -> &'static str {
+        "Rewrite the last prompt"
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(RedoCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+        })
+    }
+}
+
+struct RedoCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+}
+
+impl CommandInstance for RedoCommandInstance {
+    fn update(&mut self, _input: &str) -> CompletionResult {
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.update_tx.send(Update::Redo);
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -22,6 +22,7 @@ use tokio_stream::wrappers::WatchStream;
 
 mod app;
 mod builtins;
+mod commands;
 mod component;
 mod components;
 mod conversation;


### PR DESCRIPTION
## Summary
- factor app commands into separate `src/commands` modules
- wire App and main to load commands from the new modules
- document command module layout in AGENTS

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b05d31b9ac832a86a1a5df7ec17585