### PR TITLE
feat(llment): enable tool-aware prompt templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-openai"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1569,7 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 name = "llm"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "async-openai",
  "async-trait",
  "clap",
@@ -1581,6 +1588,7 @@ dependencies = [
 name = "llment"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "clap",
  "crossterm 0.29.0",
  "futures",

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -51,8 +51,10 @@ Trait-based LLM client implementations for multiple providers.
   - tool names are prefixed with the server name
   - `McpService` implements `ClientHandler`
     - `on_tool_list_changed` refreshes tool metadata from the service
+    - tool metadata stored in an `ArcSwap` for lock-free snapshots
   - `McpContext` stores running service handles keyed by prefix
     - exposes merged `tool_infos` from all services
+    - provides a non-blocking `tool_names` snapshot of available tools
     - implements `ToolExecutor` for MCP calls
     - tool call chunks insert assistant messages immediately before execution
     - accumulated streamed content is appended as an assistant message after the stream completes

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+arc-swap = "1.7.1"
 async-openai = { version = "0.29.0", features = ["byot"] }
 async-trait = "0.1.88"
 clap = { version = "4.5.43", features = ["derive"] }

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -70,6 +70,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `/prompt` loads a system/developer prompt from embedded markdown templates
         - `.md` files are rendered with miniJinja and may include other templates via `{% include %}`
         - templates may call `glob("pattern")` to iterate over prompt files matching a glob pattern
+        - templates may call `tool_enabled("name")` to check for available tools
         - parameters correspond to `prompts/` paths without the extension
         - selected prompts replace existing system prompts and persist across `/clear`
   - dismissable error box above the input with an X button displays request errors

--- a/crates/llment/Cargo.toml
+++ b/crates/llment/Cargo.toml
@@ -24,6 +24,7 @@ rmcp = { version = "0.4.0", features = ["client"] }
 rust-embed = "8.7.2"
 minijinja = { version = "2", features = ["loader"] }
 globset = "0.4"
+arc-swap = "1.7.1"
 
 [dev-dependencies]
 insta = "1.43.1"

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -189,7 +189,8 @@ impl App {
 
     fn apply_prompt(&mut self) {
         if let Some(name) = &self.selected_prompt {
-            if let Some(content) = commands::prompt::load_prompt(name) {
+            let tool_names = self.mcp_context.tool_names();
+            if let Some(content) = commands::prompt::load_prompt(name, tool_names) {
                 let mut history = self.chat_history.lock().unwrap();
                 while matches!(history.first(), Some(ChatMessage::System(_))) {
                     history.remove(0);
@@ -216,7 +217,7 @@ impl App {
         let mcp_context = self.mcp_context.clone();
         let client = { Arc::new(self.client.lock().unwrap().clone()) };
         self.request_tasks.spawn(async move {
-            let tool_infos = mcp_context.tool_infos().await;
+            let tool_infos = mcp_context.tool_infos();
             let model_name = { client.model().to_string() };
             let request_history = { history.lock().unwrap().clone() };
             let request = ChatMessageRequest::new(model_name, request_history)

--- a/crates/llment/src/builtins.rs
+++ b/crates/llment/src/builtins.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use arc_swap::ArcSwap;
 use llm::{ChatMessage, ToolInfo, mcp::McpService};
 use rmcp::{
     ServerHandler,
@@ -10,7 +11,7 @@ use rmcp::{
 };
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
-use tokio::{io::duplex, sync::RwLock};
+use tokio::io::duplex;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct GetMessageCountParams {}
@@ -58,11 +59,11 @@ pub async fn setup_builtin_tools(
         builtins.clone().serve(server_transport),
         McpService {
             prefix: "chat".into(),
-            tools: RwLock::new(vec![ToolInfo {
+            tools: ArcSwap::new(Arc::new(vec![ToolInfo {
                 name: "get_message_count".into(),
                 description: "Returns the number of chat messages".into(),
                 parameters: schema_for!(GetMessageCountParams),
-            }]),
+            }])),
         }
         .serve(client_transport)
     );

--- a/crates/llment/tests/prompts/sys/tool.md
+++ b/crates/llment/tests/prompts/sys/tool.md
@@ -1,0 +1,5 @@
+{% if tool_enabled("shell.run") %}
+Enabled!
+{% else %}
+Disabled!
+{% endif %}


### PR DESCRIPTION
## Summary
- allow prompts to check available tools via new `tool_enabled` helper
- pass current MCP tool list into prompt loader
- add tests for `tool_enabled` and prompt asset
- avoid blocking the runtime by snapshotting tool names synchronously
- store MCP tool metadata in `ArcSwap` for race-free snapshots and update built-in tools accordingly

## Testing
- `cargo test -p llm -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b1293913bc832a8164307ece5e6b79