### PR TITLE
fix(llment): guard shell prompts with tool_enabled

### DIFF
--- a/crates/llment/prompts/shell/apply_patch.md
+++ b/crates/llment/prompts/shell/apply_patch.md
@@ -1,3 +1,4 @@
+{% if tool_enabled("shell.run") %}
 You have access to the `apply_patch` command to edit files. Follow these rules exactly.
 
 **Contract**
@@ -47,3 +48,4 @@ You have access to the `apply_patch` command to edit files. Follow these rules e
 * Using `applypatch` or `apply-patch` (invalid names). The tool name is `apply_patch`.
 * Emitting entire file bodies as a single hunk when a small targeted hunk suffices.
 * Mixing multiple operations for the same file section; start a new section if needed.
+{% endif %}

--- a/crates/llment/prompts/shell/ls.md
+++ b/crates/llment/prompts/shell/ls.md
@@ -1,3 +1,4 @@
+{% if tool_enabled("shell.run") %}
 ## Searching and Listing Files
 
 Use `rg` -- ripgrep. Always use `rg` instead of `grep`.
@@ -22,3 +23,4 @@ To filter the list of files, use rg recursively.
 ```bash
 rg --files | rg 'md$'
 ```
+{% endif %}


### PR DESCRIPTION
## Summary
- wrap shell prompt templates in a `tool_enabled("shell.run")` guard so they only render when the shell tool is available

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b13f986460832aa1290055c79858ca