### PR TITLE
feat: add /continue command to llment

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -53,7 +53,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - clicking the field focuses it
     - cursor hidden when unfocused
     - recognizes `/` commands
-      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/model`, `/provider`, and `/prompt`
+      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/continue`, `/model`, `/provider`, and `/prompt`
         - width adjusts to content
         - `Up`/`Down` navigate selection
         - `Tab` completes and `Enter` executes
@@ -67,6 +67,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `/quit` exits the application
       - `/clear` resets conversation history, aborts any pending request, and zeroes session and context counters
       - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, aborts any pending request, and recalculates context tokens
+      - `/continue` resends the conversation without adding a new user message
       - `/prompt` loads a system/developer prompt from embedded markdown templates
         - `.md` files are rendered with miniJinja and may include other templates via `{% include %}`
         - templates may call `glob("pattern")` to iterate over prompt files matching a glob pattern

--- a/crates/llment/src/commands/continue.rs
+++ b/crates/llment/src/commands/continue.rs
@@ -1,0 +1,45 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct ContinueCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for ContinueCommand {
+    fn name(&self) -> &'static str {
+        "continue"
+    }
+    fn description(&self) -> &'static str {
+        "Request the model to continue the last response"
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ContinueCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+        })
+    }
+}
+
+struct ContinueCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+}
+
+impl CommandInstance for ContinueCommandInstance {
+    fn update(&mut self, _input: &str) -> CompletionResult {
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+    fn commit(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.update_tx.send(Update::Continue);
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod clear;
+pub mod r#continue;
 pub mod model;
 pub mod prompt;
 pub mod provider;
@@ -6,6 +7,7 @@ pub mod quit;
 pub mod redo;
 
 pub use clear::ClearCommand;
+pub use r#continue::ContinueCommand;
 pub use model::ModelCommand;
 pub use prompt::PromptCommand;
 pub use provider::ProviderCommand;


### PR DESCRIPTION
## Summary
- add `/continue` command to resend conversation without new user message
- reuse `send_request` with optional prompt instead of separate `continue_request`
- document `/continue` in llment crate guidelines

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b171271f64832a9bc57ff259f61b85