### PR TITLE
refactor(llment): extract prompt loading into module

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -110,7 +110,8 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - conversation resides under `src/conversation` with modules for nodes and mutation helpers
   - command and parameter popups are separate components under `src/components` used by the prompt input
   - app commands live in `src/commands` with one module per command
-    - `/prompt` embeds prompt assets and exposes a `load_prompt` helper
+    - `/prompt` command uses embedded prompt assets via `prompts::load_prompt`
+  - prompt assets and the `load_prompt` helper reside in `src/prompts.rs`
 - Bespoke component framework
   - `Component` trait defines `init`, `handle_event`, `update`, `render`
   - `App` orchestrates event handling, updates, and rendering via `tokio::sync::watch` channels

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -4,11 +4,12 @@ use crate::{
     Args, Component,
     builtins::setup_builtin_tools,
     commands::{
-        self, ClearCommand, ContinueCommand, ModelCommand, PromptCommand, ProviderCommand,
-        QuitCommand, RedoCommand,
+        ClearCommand, ContinueCommand, ModelCommand, PromptCommand, ProviderCommand, QuitCommand,
+        RedoCommand,
     },
     components::{ErrorPopup, Prompt, input::PromptModel},
     conversation::{Conversation, ToolStep},
+    prompts,
 };
 use crossterm::event::Event;
 use llm::{
@@ -196,7 +197,7 @@ impl App {
     fn apply_prompt(&mut self) {
         if let Some(name) = &self.selected_prompt {
             let tool_names = self.mcp_context.tool_names();
-            if let Some(content) = commands::prompt::load_prompt(name, tool_names) {
+            if let Some(content) = prompts::load_prompt(name, tool_names) {
                 let mut history = self.chat_history.lock().unwrap();
                 while matches!(history.first(), Some(ChatMessage::System(_))) {
                     history.remove(0);

--- a/crates/llment/src/commands/prompt.rs
+++ b/crates/llment/src/commands/prompt.rs
@@ -1,72 +1,10 @@
-use globset::Glob;
-use minijinja::Environment;
-use rust_embed::RustEmbed;
-use std::collections::HashSet;
 use tokio::sync::{mpsc::UnboundedSender, watch};
 
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, Completion, CompletionResult},
+    prompts::Assets,
 };
-
-#[derive(RustEmbed)]
-#[folder = "prompts"]
-struct PromptAssets;
-
-#[cfg(test)]
-#[derive(RustEmbed)]
-#[folder = "tests/prompts"]
-struct TestPromptAssets;
-
-#[cfg(test)]
-type Assets = TestPromptAssets;
-#[cfg(not(test))]
-type Assets = PromptAssets;
-
-pub(crate) fn load_prompt(
-    name: &str,
-    enabled_tools: impl IntoIterator<Item = String>,
-) -> Option<String> {
-    let enabled_tools: HashSet<String> = enabled_tools.into_iter().collect();
-    let mut env = Environment::new();
-    env.set_loader(|name| {
-        let mut candidates: Vec<String> = vec![name.to_string()];
-        if !name.ends_with(".md") {
-            candidates.push(format!("{}.md", name));
-        }
-        for candidate in candidates {
-            if let Some(file) = Assets::get(&candidate) {
-                let content = String::from_utf8_lossy(file.data.as_ref()).to_string();
-                return Ok(Some(content));
-            }
-        }
-        Ok(None)
-    });
-    env.add_function(
-        "glob",
-        |pattern: String| -> Result<Vec<String>, minijinja::Error> {
-            let glob = Glob::new(&pattern).map_err(|e| {
-                minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, e.to_string())
-            })?;
-            let matcher = glob.compile_matcher();
-            let mut matches: Vec<String> = Assets::iter()
-                .map(|f| f.as_ref().to_string())
-                .filter(|name| matcher.is_match(name))
-                .collect();
-            matches.sort();
-            Ok(matches)
-        },
-    );
-    env.add_function("tool_enabled", move |t: String| {
-        Ok(enabled_tools.contains(&t))
-    });
-    if let Ok(tmpl) = env.get_template(name) {
-        if let Ok(rendered) = tmpl.render(()) {
-            return Some(rendered);
-        }
-    }
-    None
-}
 
 pub struct PromptCommand {
     pub(crate) needs_update: watch::Sender<bool>,
@@ -138,38 +76,5 @@ impl CommandInstance for PromptCommandInstance {
             let _ = self.needs_update.send(true);
             Ok(())
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::load_prompt;
-
-    #[test]
-    fn load_md_prompt() {
-        let content = load_prompt("sys/hello", Vec::new()).unwrap();
-        assert!(content.contains("You are a helpful assistant."));
-    }
-
-    #[test]
-    fn load_md_with_include() {
-        let content = load_prompt("sys/outer", Vec::new()).unwrap();
-        assert!(content.contains("Outer."));
-        assert!(content.contains("Inner."));
-        assert!(content.contains("Deep."));
-    }
-
-    #[test]
-    fn load_md_with_glob() {
-        let content = load_prompt("sys/glob", Vec::new()).unwrap();
-        assert!(content.contains("You are a helpful assistant."));
-    }
-
-    #[test]
-    fn tool_enabled_fn() {
-        let content = load_prompt("sys/tool", vec!["shell.run".to_string()]).unwrap();
-        assert!(content.contains("Enabled!"));
-        let content = load_prompt("sys/tool", Vec::new()).unwrap();
-        assert!(content.contains("Disabled!"));
     }
 }

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -27,6 +27,7 @@ mod component;
 mod components;
 mod conversation;
 mod markdown;
+mod prompts;
 
 use llm::mcp::{McpContext, load_mcp_servers};
 use llm::{self, Provider};

--- a/crates/llment/src/prompts.rs
+++ b/crates/llment/src/prompts.rs
@@ -1,0 +1,96 @@
+use globset::Glob;
+use minijinja::Environment;
+use rust_embed::RustEmbed;
+use std::collections::HashSet;
+
+#[derive(RustEmbed)]
+#[folder = "prompts"]
+pub(crate) struct PromptAssets;
+
+#[cfg(test)]
+#[derive(RustEmbed)]
+#[folder = "tests/prompts"]
+pub(crate) struct TestPromptAssets;
+
+#[cfg(test)]
+pub(crate) type Assets = TestPromptAssets;
+#[cfg(not(test))]
+pub(crate) type Assets = PromptAssets;
+
+pub(crate) fn load_prompt(
+    name: &str,
+    enabled_tools: impl IntoIterator<Item = String>,
+) -> Option<String> {
+    let enabled_tools: HashSet<String> = enabled_tools.into_iter().collect();
+    let mut env = Environment::new();
+    env.set_loader(|name| {
+        let mut candidates: Vec<String> = vec![name.to_string()];
+        if !name.ends_with(".md") {
+            candidates.push(format!("{}.md", name));
+        }
+        for candidate in candidates {
+            if let Some(file) = Assets::get(&candidate) {
+                let content = String::from_utf8_lossy(file.data.as_ref()).to_string();
+                return Ok(Some(content));
+            }
+        }
+        Ok(None)
+    });
+    env.add_function(
+        "glob",
+        |pattern: String| -> Result<Vec<String>, minijinja::Error> {
+            let glob = Glob::new(&pattern).map_err(|e| {
+                minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, e.to_string())
+            })?;
+            let matcher = glob.compile_matcher();
+            let mut matches: Vec<String> = Assets::iter()
+                .map(|f| f.as_ref().to_string())
+                .filter(|name| matcher.is_match(name))
+                .collect();
+            matches.sort();
+            Ok(matches)
+        },
+    );
+    env.add_function("tool_enabled", move |t: String| {
+        Ok(enabled_tools.contains(&t))
+    });
+    if let Ok(tmpl) = env.get_template(name) {
+        if let Ok(rendered) = tmpl.render(()) {
+            return Some(rendered);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_prompt;
+
+    #[test]
+    fn load_md_prompt() {
+        let content = load_prompt("sys/hello", Vec::new()).unwrap();
+        assert!(content.contains("You are a helpful assistant."));
+    }
+
+    #[test]
+    fn load_md_with_include() {
+        let content = load_prompt("sys/outer", Vec::new()).unwrap();
+        assert!(content.contains("Outer."));
+        assert!(content.contains("Inner."));
+        assert!(content.contains("Deep."));
+    }
+
+    #[test]
+    fn load_md_with_glob() {
+        let content = load_prompt("sys/glob", Vec::new()).unwrap();
+        assert!(content.contains("You are a helpful assistant."));
+    }
+
+    #[test]
+    fn tool_enabled_fn() {
+        let content = load_prompt("sys/tool", vec!["shell.run".to_string()]).unwrap();
+        assert!(content.contains("Enabled!"));
+        let content = load_prompt("sys/tool", Vec::new()).unwrap();
+        assert!(content.contains("Disabled!"));
+    }
+}


### PR DESCRIPTION
## Summary
- move prompt loading logic and tests into new `prompts` module
- wire `/prompt` command and app to use `prompts::load_prompt`
- document new prompt module in AGENTS

## Testing
- `cargo fmt --all`
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b1970a8c8c832aa16a6f2e03c967ee