### PR TITLE
feat(llment): add repair command and history reset

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -53,7 +53,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - clicking the field focuses it
     - cursor hidden when unfocused
     - recognizes `/` commands
-      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/continue`, `/model`, `/provider`, and `/prompt`
+      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/model`, `/provider`, and `/prompt`
         - width adjusts to content
         - `Up`/`Down` navigate selection
         - `Tab` completes and `Enter` executes
@@ -67,6 +67,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `/quit` exits the application
       - `/clear` resets conversation history, aborts any pending request, and zeroes session and context counters
       - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, aborts any pending request, and recalculates context tokens
+      - `/repair` removes assistant blocks with no content or tool calls
       - `/continue` resends the conversation without adding a new user message
       - `/prompt` loads a system/developer prompt from embedded markdown templates
         - `.md` files are rendered with miniJinja and may include other templates via `{% include %}`
@@ -90,6 +91,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - history, error, or clear updates reset to idle
   - conversation items
     - initialized with empty history
+    - history can be rebuilt from a full `ChatMessage` sequence
     - user messages render inside a right-aligned rounded block
     - assistant messages show working steps and final response
       - working and tool sections toggle with mouse click

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod prompt;
 pub mod provider;
 pub mod quit;
 pub mod redo;
+pub mod repair;
 
 pub use clear::ClearCommand;
 pub use r#continue::ContinueCommand;
@@ -13,3 +14,4 @@ pub use prompt::PromptCommand;
 pub use provider::ProviderCommand;
 pub use quit::QuitCommand;
 pub use redo::RedoCommand;
+pub use repair::RepairCommand;

--- a/crates/llment/src/commands/repair.rs
+++ b/crates/llment/src/commands/repair.rs
@@ -1,0 +1,45 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct RepairCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for RepairCommand {
+    fn name(&self) -> &'static str {
+        "repair"
+    }
+    fn description(&self) -> &'static str {
+        "Remove empty assistant blocks"
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(RepairCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+        })
+    }
+}
+
+struct RepairCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+}
+
+impl CommandInstance for RepairCommandInstance {
+    fn update(&mut self, _input: &str) -> CompletionResult {
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+    fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self.update_tx.send(Update::Repair);
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -287,27 +287,6 @@ impl Conversation {
         None
     }
 
-    pub fn repair(&mut self) -> bool {
-        let mut removed = false;
-        self.items.retain(|item| {
-            if let Node::Assistant(block) = item {
-                let has_response = !block.response.trim().is_empty();
-                let has_tool = block.steps.iter().any(|s| matches!(s, Node::Tool(_)));
-                if !has_response && !has_tool {
-                    removed = true;
-                    return false;
-                }
-            }
-            true
-        });
-        if removed {
-            self.needs_layout = true;
-            self.ensure_layout(self.width);
-            self.scroll_to_bottom();
-        }
-        removed
-    }
-
     pub fn set_history(&mut self, history: &[ChatMessage]) {
         self.clear();
         let mut i = 0usize;
@@ -465,19 +444,5 @@ mod tests {
 [Reset,Reset]│ word4 word5 word6
 [Reset,Reset]│ word7 word8 word9
 [Reset,Reset]│ word10 word11");
-    }
-
-    #[test]
-    fn repair_removes_empty_blocks() {
-        let mut conv = Conversation::new();
-        conv.items.push(Node::Assistant(AssistantBlock::new(
-            false,
-            vec![Node::Thought(ThoughtStep::new("thinking".into()))],
-            String::new(),
-        )));
-        conv.items.push(Node::User(UserBubble::new("hi".into())));
-        assert!(conv.repair());
-        assert_eq!(conv.items.len(), 1);
-        assert!(matches!(conv.items[0], Node::User(_)));
     }
 }


### PR DESCRIPTION
## Summary
- add `/repair` command to drop empty assistant blocks
- rebuild conversation from full `ChatMessage` history
- ensure conversation rebuilds from sanitized history after repair

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b1a65aa1d8832abdf79afa77c72ba3