### PR TITLE
refactor(llment): rebuild history via public api

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -93,6 +93,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - conversation items
     - initialized with empty history
     - history can be rebuilt from a full `ChatMessage` sequence
+      - standalone `Tool` messages are supported
     - user messages render inside a right-aligned rounded block
     - assistant messages show working steps and final response
       - may include multiple responses before tool calls

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -348,6 +348,19 @@ impl Conversation {
                         break;
                     }
                 }
+                ChatMessage::Tool(tmsg) => {
+                    let step_id = tool_id;
+                    tool_id += 1;
+                    let mut step = ToolStep::new(
+                        tmsg.id.clone(),
+                        step_id,
+                        String::new(),
+                        tmsg.content.to_string(),
+                        false,
+                    );
+                    step.done = true;
+                    self.add_tool_step(step);
+                }
                 _ => {}
             }
             i += 1;


### PR DESCRIPTION
## Summary
- refactor conversation history reconstruction to call public APIs instead of mutating state directly

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b2e598a734832abea5f18d71a90fde