### PR TITLE
fix(llm): omit empty fields during chat serialization

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -38,6 +38,7 @@ Trait-based LLM client implementations for multiple providers.
     - tool calls include an `id` string, assigned locally when missing
     - tool messages carry the same `id` and store `content` as `serde_json::Value`
 - Chat message, request, and response types serialize to and from JSON
+  - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses
   - chunks include optional content, tool calls, optional thinking text, and usage metrics on the final chunk
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -9,6 +9,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, to_value};
 use tokio_stream::Stream;
 
+fn option_string_is_empty(value: &Option<String>) -> bool {
+    match value {
+        None => true,
+        Some(s) => s.is_empty(),
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "role", rename_all = "snake_case")]
 pub enum ChatMessage {
@@ -46,19 +53,23 @@ impl ChatMessage {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserMessage {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AssistantMessage {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_calls: Vec<ToolCall>,
+    #[serde(skip_serializing_if = "option_string_is_empty", default)]
     pub thinking: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SystemMessage {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content: String,
 }
 
@@ -87,8 +98,9 @@ pub struct ToolInfo {
 pub struct ChatMessageRequest {
     pub model_name: String,
     pub messages: Vec<ChatMessage>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<ToolInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub think: Option<bool>,
 }
 
@@ -188,9 +200,11 @@ pub fn client_from(
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponseMessage {
+    #[serde(default, skip_serializing_if = "option_string_is_empty")]
     pub content: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tool_calls: Vec<ToolCall>,
+    #[serde(default, skip_serializing_if = "option_string_is_empty")]
     pub thinking: Option<String>,
 }
 
@@ -204,6 +218,7 @@ pub struct Usage {
 pub struct ResponseChunk {
     pub message: ResponseMessage,
     pub done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
 }
 


### PR DESCRIPTION
## Summary
- skip serialization of None/empty strings/arrays in chat messages, requests, and responses

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b3b5e1f8c4832a9ebbd9411a0cdef1