### PR TITLE
feat: add agent mode command

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -55,6 +55,7 @@ Trait-based LLM client implementations for multiple providers.
     - `on_tool_list_changed` refreshes tool metadata from the service
     - tool metadata stored in an `ArcSwap` for lock-free snapshots
   - `McpContext` stores running service handles keyed by prefix
+    - supports runtime insertion and removal of services via internal locking
     - exposes merged `tool_infos` from all services
     - provides a non-blocking `tool_names` snapshot of available tools
     - implements `ToolExecutor` for MCP calls

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -54,7 +54,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - clicking the field focuses it
     - cursor hidden when unfocused
     - recognizes `/` commands
-      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/save`, `/load`, `/model`, `/provider`, and `/prompt`
+      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/save`, `/load`, `/model`, `/provider`, `/prompt`, and `/agent-mode`
         - width adjusts to content
         - `Up`/`Down` navigate selection
         - `Tab` completes and `Enter` executes
@@ -78,6 +78,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - templates may call `tool_enabled("name")` to check for available tools
         - parameters correspond to `prompts/` paths without the extension
         - selecting a prompt sets it as active; it is applied to conversation history when a request is sent (including `/continue`) and persists across `/clear`
+      - `/agent-mode` resets history and activates an agent mode that drives follow-up prompts
       - command commit behavior
         - on successful commit, the router clears the active command instance
         - on commit error, the active command instance remains for user correction

--- a/crates/llment/src/commands/agent_mode.rs
+++ b/crates/llment/src/commands/agent_mode.rs
@@ -1,0 +1,78 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, Completion, CompletionResult},
+    modes,
+};
+
+pub struct AgentModeCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for AgentModeCommand {
+    fn name(&self) -> &'static str {
+        "agent-mode"
+    }
+    fn description(&self) -> &'static str {
+        "Activate an agent mode"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(AgentModeCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+            param: String::new(),
+        })
+    }
+}
+
+struct AgentModeCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+    param: String,
+}
+
+impl AgentModeCommandInstance {
+    fn mode_options(&self, typed: &str) -> Vec<Completion> {
+        let mut options: Vec<Completion> = modes::available_modes()
+            .into_iter()
+            .filter(|m| m.starts_with(typed))
+            .map(|m| Completion {
+                name: m.to_string(),
+                description: String::new(),
+                str: m.to_string(),
+            })
+            .collect();
+        options.sort_by(|a, b| a.name.cmp(&b.name));
+        options
+    }
+}
+
+impl CommandInstance for AgentModeCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        self.param = input.trim().to_string();
+        let options = self.mode_options(self.param.as_str());
+        CompletionResult::Options { at: 0, options }
+    }
+    fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.param.is_empty() {
+            Err("no mode".into())
+        } else {
+            let mode_name = self.param.clone();
+            let tx = self.update_tx.clone();
+            let needs_update = self.needs_update.clone();
+            tokio::spawn(async move {
+                if let Some((mode, service)) = modes::create_agent_mode(&mode_name).await {
+                    let _ = tx.send(Update::Clear);
+                    let _ = tx.send(Update::SetMode(mode, service));
+                    let _ = needs_update.send(true);
+                }
+            });
+            Ok(())
+        }
+    }
+}

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_mode;
 pub mod clear;
 pub mod r#continue;
 pub mod load;
@@ -9,6 +10,7 @@ pub mod redo;
 pub mod repair;
 pub mod save;
 
+pub use agent_mode::AgentModeCommand;
 pub use clear::ClearCommand;
 pub use r#continue::ContinueCommand;
 pub use load::LoadCommand;

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -27,6 +27,7 @@ mod component;
 mod components;
 mod conversation;
 mod markdown;
+mod modes;
 mod prompts;
 
 use llm::mcp::{McpContext, load_mcp_servers};

--- a/crates/llment/src/modes/example.rs
+++ b/crates/llment/src/modes/example.rs
@@ -1,0 +1,33 @@
+use super::AgentMode;
+
+pub struct ExampleAgentMode {
+    stage: usize,
+}
+
+impl ExampleAgentMode {
+    pub fn new() -> Self {
+        Self { stage: 0 }
+    }
+}
+
+impl AgentMode for ExampleAgentMode {
+    fn start(&mut self) -> (String, String) {
+        self.stage = 1;
+        (
+            "default".to_string(),
+            "Hello from the example agent mode.".to_string(),
+        )
+    }
+
+    fn step(&mut self) -> (String, Option<String>) {
+        if self.stage == 1 {
+            self.stage = 2;
+            (
+                "default".to_string(),
+                Some("This is a follow-up from example agent mode.".to_string()),
+            )
+        } else {
+            ("default".to_string(), None)
+        }
+    }
+}

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -1,0 +1,25 @@
+use llm::mcp::McpService;
+use rmcp::service::{RoleClient, RunningService};
+
+pub trait AgentMode: Send {
+    fn start(&mut self) -> (String, String);
+    fn step(&mut self) -> (String, Option<String>);
+}
+
+pub async fn create_agent_mode(
+    name: &str,
+) -> Option<(
+    Box<dyn AgentMode>,
+    Option<RunningService<RoleClient, McpService>>,
+)> {
+    match name {
+        "example" => Some((Box::new(example::ExampleAgentMode::new()), None)),
+        _ => None,
+    }
+}
+
+pub fn available_modes() -> Vec<&'static str> {
+    vec!["example"]
+}
+
+mod example;


### PR DESCRIPTION
## Summary
- add `/agent-mode` command to reset conversation and start stateful modes
- support runtime MCP services with internally locked `McpContext`
- include example agent mode demonstrating start/step workflow

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b4332fc8cc832ab187757120dc7b90