### PR TITLE
feat(llment): split prompt and role management

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -54,7 +54,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - clicking the field focuses it
     - cursor hidden when unfocused
     - recognizes `/` commands
-      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/save`, `/load`, `/model`, `/provider`, `/prompt`, and `/agent-mode`
+      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/save`, `/load`, `/model`, `/provider`, `/prompt`, `/role`, and `/agent-mode`
         - width adjusts to content
         - `Up`/`Down` navigate selection
         - `Tab` completes and `Enter` executes
@@ -72,13 +72,17 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `/continue` resends the conversation without adding a new user message
       - `/save` writes conversation history to a file
       - `/load` restores conversation history from a file and aborts any pending request
-      - `/prompt` loads a system/developer prompt from embedded markdown templates
+      - default prompt `default` is active on startup; default role is none
+      - `/prompt` loads a root prompt from embedded markdown templates
         - `.md` files are rendered with miniJinja and may include other templates via `{% include %}`
         - templates may call `glob("pattern")` to iterate over prompt files matching a glob pattern
         - templates may call `tool_enabled("name")` to check for available tools
         - parameters correspond to `prompts/` paths without the extension
         - selecting a prompt sets it as active; it is applied to conversation history when a request is sent (including `/continue`) and persists across `/clear`
-      - `/agent-mode` resets history and activates an agent mode that drives follow-up prompts
+      - `/role` loads a role from `prompts/roles`
+        - passing `none` clears the active role
+      - `/agent-mode` resets history, optionally sets a role, and activates an agent mode that drives follow-up prompts
+        - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service that is added on start and removed when switching modes
         - `/agent-mode off` exits the active agent mode
       - command commit behavior
@@ -87,7 +91,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - dismissable error box above the input with an X button displays request errors
   - Esc exits the application
   - 1-line status area
-    - shows state, provider, and model on the left
+    - shows state, provider, model, and active prompt and role when set on the left
     - right-aligned: `ctx <context_tokens>t, Σ <session_in_tokens>t=> <session_out_tokens>t`
   - conversation state tracking
     - states: idle, thinking, calling tool, responding
@@ -121,8 +125,9 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - conversation resides under `src/conversation` with modules for nodes and mutation helpers
   - command and parameter popups are separate components under `src/components` used by the prompt input
   - app commands live in `src/commands` with one module per command
-    - `/prompt` command uses embedded prompt assets via `prompts::load_prompt`
+    - `/prompt` and `/role` commands use embedded prompt assets via `prompts::load_prompt`
   - prompt assets and the `load_prompt` helper reside in `src/prompts.rs`
+    - `load_prompt` registers `glob("pattern")`, `tool_enabled("name")`, and `role()` functions for templates
 - Bespoke component framework
   - `Component` trait defines `init`, `handle_event`, `update`, `render`
   - `App` orchestrates event handling, updates, and rendering via `tokio::sync::watch` channels

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -82,6 +82,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - `/role` loads a role from `prompts/roles`
         - passing `none` clears the active role
       - `/agent-mode` resets history, optionally sets a role, and activates an agent mode that drives follow-up prompts
+        - agent mode `start` and `step` return results with `role` and `prompt` fields
         - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service that is added on start and removed when switching modes
         - `/agent-mode off` exits the active agent mode

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -81,6 +81,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - selecting a prompt sets it as active; it is applied to conversation history when a request is sent (including `/continue`) and persists across `/clear`
       - `/role` loads a role from `prompts/roles`
         - passing `none` clears the active role
+        - completion suggestions include roles matching the typed prefix and `none` when it matches
       - `/agent-mode` resets history, optionally sets a role, and activates an agent mode that drives follow-up prompts
         - agent mode `start` and `step` return results with `role` and `prompt` fields
         - agent modes may adjust or clear the role between steps

--- a/crates/llment/prompts/default.md
+++ b/crates/llment/prompts/default.md
@@ -1,4 +1,4 @@
-{% include "roles/swe.md" %}
+{{ role() }}
 {% include "instructions/focus.md" %}
 {% include "instructions/task.md" %}
 {% include "instructions/autonomy.md" %}

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -364,9 +364,9 @@ impl Component for App {
                 Ok(Update::ResponseComplete) => {
                     self.state = ConversationState::Idle;
                     if let Some(mode) = self.mode.as_mut() {
-                        let (role_name, prompt) = mode.step();
-                        self.selected_role = role_name;
-                        if let Some(prompt) = prompt {
+                        let step = mode.step();
+                        self.selected_role = step.role;
+                        if let Some(prompt) = step.prompt {
                             self.send_request(Some(prompt));
                         }
                     }
@@ -414,9 +414,9 @@ impl Component for App {
                         if let Some(service) = service {
                             self.mcp_context.insert(service);
                         }
-                        let (role_name, prompt) = mode.start();
-                        self.selected_role = role_name;
-                        self.send_request(Some(prompt));
+                        let start = mode.start();
+                        self.selected_role = start.role;
+                        self.send_request(Some(start.prompt));
                     } else {
                         self.selected_role = None;
                     }

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod provider;
 pub mod quit;
 pub mod redo;
 pub mod repair;
+pub mod role;
 pub mod save;
 
 pub use agent_mode::AgentModeCommand;
@@ -20,4 +21,5 @@ pub use provider::ProviderCommand;
 pub use quit::QuitCommand;
 pub use redo::RedoCommand;
 pub use repair::RepairCommand;
+pub use role::RoleCommand;
 pub use save::SaveCommand;

--- a/crates/llment/src/commands/role.rs
+++ b/crates/llment/src/commands/role.rs
@@ -53,7 +53,9 @@ impl RoleCommandInstance {
                 }
             })
             .collect();
-        names.push("none".to_string());
+        if "none".starts_with(typed) {
+            names.push("none".to_string());
+        }
         names.sort();
         names.dedup();
         names

--- a/crates/llment/src/modes/example.rs
+++ b/crates/llment/src/modes/example.rs
@@ -11,23 +11,23 @@ impl ExampleAgentMode {
 }
 
 impl AgentMode for ExampleAgentMode {
-    fn start(&mut self) -> (String, String) {
+    fn start(&mut self) -> (Option<String>, String) {
         self.stage = 1;
         (
-            "default".to_string(),
+            Some("swe".to_string()),
             "Hello from the example agent mode.".to_string(),
         )
     }
 
-    fn step(&mut self) -> (String, Option<String>) {
+    fn step(&mut self) -> (Option<String>, Option<String>) {
         if self.stage == 1 {
             self.stage = 2;
             (
-                "default".to_string(),
+                Some("swe".to_string()),
                 Some("This is a follow-up from example agent mode.".to_string()),
             )
         } else {
-            ("default".to_string(), None)
+            (None, None)
         }
     }
 }

--- a/crates/llment/src/modes/example.rs
+++ b/crates/llment/src/modes/example.rs
@@ -1,4 +1,4 @@
-use super::AgentMode;
+use super::{AgentMode, AgentModeStart, AgentModeStep};
 
 pub struct ExampleAgentMode {
     stage: usize,
@@ -11,23 +11,26 @@ impl ExampleAgentMode {
 }
 
 impl AgentMode for ExampleAgentMode {
-    fn start(&mut self) -> (Option<String>, String) {
+    fn start(&mut self) -> AgentModeStart {
         self.stage = 1;
-        (
-            Some("swe".to_string()),
-            "Hello from the example agent mode.".to_string(),
-        )
+        AgentModeStart {
+            role: Some("swe".to_string()),
+            prompt: "Hello from the example agent mode.".to_string(),
+        }
     }
 
-    fn step(&mut self) -> (Option<String>, Option<String>) {
+    fn step(&mut self) -> AgentModeStep {
         if self.stage == 1 {
             self.stage = 2;
-            (
-                Some("swe".to_string()),
-                Some("This is a follow-up from example agent mode.".to_string()),
-            )
+            AgentModeStep {
+                role: Some("swe".to_string()),
+                prompt: Some("This is a follow-up from example agent mode.".to_string()),
+            }
         } else {
-            (None, None)
+            AgentModeStep {
+                role: None,
+                prompt: None,
+            }
         }
     }
 }

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -1,9 +1,19 @@
 use llm::mcp::McpService;
 use rmcp::service::{RoleClient, RunningService};
 
+pub struct AgentModeStart {
+    pub role: Option<String>,
+    pub prompt: String,
+}
+
+pub struct AgentModeStep {
+    pub role: Option<String>,
+    pub prompt: Option<String>,
+}
+
 pub trait AgentMode: Send {
-    fn start(&mut self) -> (Option<String>, String);
-    fn step(&mut self) -> (Option<String>, Option<String>);
+    fn start(&mut self) -> AgentModeStart;
+    fn step(&mut self) -> AgentModeStep;
     fn service_prefix(&self) -> Option<&str> {
         None
     }

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -2,8 +2,8 @@ use llm::mcp::McpService;
 use rmcp::service::{RoleClient, RunningService};
 
 pub trait AgentMode: Send {
-    fn start(&mut self) -> (String, String);
-    fn step(&mut self) -> (String, Option<String>);
+    fn start(&mut self) -> (Option<String>, String);
+    fn step(&mut self) -> (Option<String>, Option<String>);
     fn service_prefix(&self) -> Option<&str> {
         None
     }


### PR DESCRIPTION
## Summary
- separate `/prompt` root prompt selection from new `/role` command
- wire role into `load_prompt` via `role()` Jinja helper and update default template
- default prompt is `default` with no role; agent modes now return roles
- status bar shows active prompt and role; agent modes can clear role

## Testing
- `cargo fmt`
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b440929dec832aa5ede38a82e663c1