### PR TITLE
refactor(llment): hardcode agent service prefix

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -88,7 +88,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
           - `prompt` set to `None` sends a request without a new user message
         - agent mode `step` can signal `stop` to exit the mode
         - agent modes may adjust or clear the role between steps
-        - agent modes may register an MCP service that is added on start and removed when switching modes or when the mode stops
+        - agent modes may register an MCP service under the `agent` prefix that is added on start and removed when switching modes or when the mode stops
         - `/agent-mode off` exits the active agent mode
       - command commit behavior
         - on successful commit, the router clears the active command instance
@@ -155,4 +155,4 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 - switching model aborts in-flight requests without clearing history or resetting token counters
 - partial items are clipped when scrolled
 - collapsed content does not contribute to layout height
-- MCP tool names are prefixed with the server name; built-in tools use the `chat` prefix
+- MCP tool names are prefixed with the server name; built-in tools use the `chat` prefix, agent mode tools use the `agent` prefix

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -375,11 +375,7 @@ impl Component for App {
                         }
                         self.selected_role = step.role;
                         if step.stop {
-                            if let Some(mode) = self.mode.as_ref() {
-                                if let Some(prefix) = mode.service_prefix() {
-                                    self.mcp_context.remove(prefix);
-                                }
-                            }
+                            self.mcp_context.remove("agent");
                             self.mode = None;
                         } else {
                             self.send_request(step.prompt);
@@ -418,11 +414,7 @@ impl Component for App {
                     self.selected_role = role;
                 }
                 Ok(Update::SetMode(mode, service)) => {
-                    if let Some(current) = self.mode.as_ref() {
-                        if let Some(prefix) = current.service_prefix() {
-                            self.mcp_context.remove(prefix);
-                        }
-                    }
+                    self.mcp_context.remove("agent");
                     self.abort_requests();
                     self.mode = mode;
                     if let Some(service) = service {

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -17,9 +17,6 @@ pub struct AgentModeStep {
 pub trait AgentMode: Send {
     fn start(&mut self) -> AgentModeStart;
     fn step(&mut self) -> AgentModeStep;
-    fn service_prefix(&self) -> Option<&str> {
-        None
-    }
 }
 
 pub async fn create_agent_mode(


### PR DESCRIPTION
## Summary
- hardcode agent-mode MCP service prefix to `agent`
- remove mode-specific service prefix API

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b459289fc4832aafc474bbeb7f22b4