### PR TITLE
feat(llment): add code agent mode with MCP notify tool

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -90,6 +90,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service under the `agent` prefix that is added on start and removed when switching modes or when the mode stops
         - available modes include `code-agent` coordinating director, design-lead, execution-lead, eng-team, and reviewer roles via an `agent.notify` MCP tool
+          - `agent.notify` accepts `role` values of `director`, `design-lead`, `execution-lead`, `eng-team`, or `reviewer`
         - `/agent-mode off` exits the active agent mode
       - command commit behavior
         - on successful commit, the router clears the active command instance

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -89,6 +89,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - agent mode `step` can signal `stop` to exit the mode
         - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service under the `agent` prefix that is added on start and removed when switching modes or when the mode stops
+        - available modes include `code-agent` coordinating director, design-lead, execution-lead, eng-team, and reviewer roles via an `agent.notify` MCP tool
         - `/agent-mode off` exits the active agent mode
       - command commit behavior
         - on successful commit, the router clears the active command instance

--- a/crates/llment/prompts/roles/code-agent/design-lead.md
+++ b/crates/llment/prompts/roles/code-agent/design-lead.md
@@ -1,15 +1,16 @@
-The overall objective that we are working towards is in `objective.md`.
+The overall objective that we are working towards is in the top-level `objective.md`.
 
 You may read and understand that file, but do not edit it.
 
-The work plan is in `plan.md`. If we are just starting, this file may be missing or empty.
+The work plan is in the top-level `plan.md`. If we are just starting, this file may be missing or empty — create or update it as needed.
 
 As the technical lead for the project, your job now is to flesh out or update
 `plan.md` with respect to the current contents of the workspace. Your plan
-should define the components that we need to build, and outline the dependencies
-between them that will influence the order that they are worked on. Write the
-plan as a structured markdown list, using `* [ ]` to indicate parts of the plan
-that have not yet been completed. You may summarize or edit parts that have been
-completed as necessary.
+should define the components that we need to build, outline the dependencies
+between them that will influence the order that they are worked on, and include
+clear acceptance criteria for major items. Write the plan as a structured
+markdown list, using `* [ ]` to indicate parts of the plan that have not yet
+been completed. You may summarize or edit parts that have been completed as
+necessary. Prefer nested checklists to express dependencies and sub-tasks.
 
 When you are done, use git to commit your changes, call agent.notify for role `execution-lead` and stop.

--- a/crates/llment/prompts/roles/code-agent/design-lead.md
+++ b/crates/llment/prompts/roles/code-agent/design-lead.md
@@ -1,10 +1,11 @@
 The overall objective that we are working towards is in the top-level `objective.md`.
 
-You may read and understand that file, but do not edit it.
+Read and understand that file, but do not edit it.
 
-The work plan is in the top-level `plan.md`. If we are just starting, this file may be missing or empty — create or update it as needed.
+The work plan is in the top-level `plan.md`. Read this file.
+If we are just starting, this file may be missing or empty.
 
-As the technical lead for the project, your job now is to flesh out or update
+As the technical lead for the project, your job now is to create or update
 `plan.md` with respect to the current contents of the workspace. Your plan
 should define the components that we need to build, outline the dependencies
 between them that will influence the order that they are worked on, and include
@@ -13,4 +14,9 @@ markdown list, using `* [ ]` to indicate parts of the plan that have not yet
 been completed. You may summarize or edit parts that have been completed as
 necessary. Prefer nested checklists to express dependencies and sub-tasks.
 
-When you are done, use git to commit your changes, call agent.notify for role `execution-lead` and stop.
+Do not modify any other files in the workspace, leave that to the team.
+
+When you are finished:
+1. use git to commit your changes, make sure the working directory is clean before continuing
+2. call agent.notify for role `execution-lead`
+3. stop

--- a/crates/llment/prompts/roles/code-agent/director.md
+++ b/crates/llment/prompts/roles/code-agent/director.md
@@ -1,5 +1,7 @@
 Analyze the content of the workspace.
 
+If there exists a top-level `task.md` file, then call agent.notify for role `eng-team`, ask them to resume their work, and stop.
+
 If there is already a top-level `objective.md` file, then call agent.notify for role `design-lead` and stop.
 
-Otherwise, discuss with the user what the objective should be; once you have enough information, write the objective to the top-level `objective.md`, use git to commit the change, and then call agent.notify for role `design-lead` and stop.
+Otherwise, discuss with the user what the objective should be; once you have enough information, after confirming with the user, write the objective to the top-level `objective.md`, use git to commit the change, and then call agent.notify for role `design-lead` and stop.

--- a/crates/llment/prompts/roles/code-agent/director.md
+++ b/crates/llment/prompts/roles/code-agent/director.md
@@ -2,4 +2,4 @@ Analyze the content of the workspace.
 
 If there is already a top-level `objective.md` file, then call agent.notify for role `design-lead` and stop.
 
-Otherwise, discuss with the user what the objective should be, once you have enough information, write the objective to the file, use git to commit the change, and then call agent.notify for role `design-lead` and stop.
+Otherwise, discuss with the user what the objective should be; once you have enough information, write the objective to the top-level `objective.md`, use git to commit the change, and then call agent.notify for role `design-lead` and stop.

--- a/crates/llment/prompts/roles/code-agent/eng-team.md
+++ b/crates/llment/prompts/roles/code-agent/eng-team.md
@@ -1,12 +1,12 @@
-The overall objective that we are working towards is in `objective.md`.
+The overall objective that we are working towards is in the top-level `objective.md`.
 
-The work plan is in `plan.md`.
+The work plan is in the top-level `plan.md`.
 
-Your current task is in `task.md`.
+Your current task is in the top-level `task.md`.
 
 You may read and understand those files, but do not edit them.
 
-Your current todo list and notes on your work are in `task-log.md`, if you're just starting, it may be empty -- please fill it out.
+Your current todo list and notes on your work are in the top-level `task-log.md`. If you're just starting, it may be empty — please fill it out.
 As you make progress on your task, update your todo list -- you can check off items as you complete them `* [x]`, or add new items `* [ ]`.
 
-When you are finished all the items, use git to commit your changes, then call agent.notify for role `reviewer`, summarize any deviations from the task.
+When you are finished with all the items, use git to commit your changes, call agent.notify for role `reviewer`, and summarize any deviations from the task, and stop.

--- a/crates/llment/prompts/roles/code-agent/eng-team.md
+++ b/crates/llment/prompts/roles/code-agent/eng-team.md
@@ -1,12 +1,25 @@
+You are a software engineer, part of a team, and have been assigned a task to implement.
+
 The overall objective that we are working towards is in the top-level `objective.md`.
 
 The work plan is in the top-level `plan.md`.
 
 Your current task is in the top-level `task.md`.
 
-You may read and understand those files, but do not edit them.
+First, read and understand those files, but do not edit them.
 
-Your current todo list and notes on your work are in the top-level `task-log.md`. If you're just starting, it may be empty — please fill it out.
-As you make progress on your task, update your todo list -- you can check off items as you complete them `* [x]`, or add new items `* [ ]`.
+Your current todo list and notes on your work are in the top-level `task-log.md`. Read this file.
+It may be empty or missing if you are just starting, create it and fill it out.
+If you are resuming work, check git status, and git log -n 1
 
-When you are finished with all the items, use git to commit your changes, call agent.notify for role `reviewer`, and summarize any deviations from the task, and stop.
+Begin work on the task.
+* think about how you are going to tackle it, write summary and add a TODO list to the task-log.
+ * add new items `* [ ]`
+* as you work through the items one by one, mark them off `* [x]`
+* as you learn things, update the log with notes, it may be useful if you have to resume the task later
+
+When you are finished:
+1. ensure the task log is up to date - did you complete all the TODOs?
+2. use git to commit your changes, make sure the working directory is clean before continuing (git status)
+3. call agent.notify for role `reviewer` summarizing any deviations from the task
+4. stop

--- a/crates/llment/prompts/roles/code-agent/execution-lead.md
+++ b/crates/llment/prompts/roles/code-agent/execution-lead.md
@@ -1,12 +1,15 @@
 The overall objective that we are working towards is in the top-level `objective.md`.
 
-You may read and understand that file, but do not edit it.
+First, read and understand that file, but do not edit it.
 
 The work plan is in the top-level `plan.md`.
 
-The task that was most recently completed is in the top-level `task.md`. A log describing how the task was completed is in the top-level `task-log.md`. If there was no previous task, those two files will be missing.
+The task that was most recently completed is in the top-level `task.md`.
+A log describing how the task was completed is in the top-level `task-log.md`.
+If there was no previous task, those two files will be missing.
 
 As the technical lead for the project, your job now is:
+* Read plan, task and task log.
 * Update `plan.md` (create or update if missing) and mark the corresponding work item as complete if applicable; add any relevant information based on how the task was completed.
 * Decide which task makes sense to work on next. Create or replace `task.md` with the specification for the new task, including:
   * Scope and deliverables
@@ -15,4 +18,9 @@ As the technical lead for the project, your job now is:
   * A baseline commit SHA (e.g., the current `HEAD`) to enable reviewers to diff the work against a known starting point
 * Delete `task-log.md` if it exists.
 
-When you are done, use git to commit your changes, call agent.notify for role `eng-team` and stop.
+Do not modify any other files in the workspace, leave that to the eng team.
+
+When you are finished:
+1. use git to commit your changes, make sure the working directory is clean before continuing
+2. call agent.notify for role `eng-team`
+3. stop.

--- a/crates/llment/prompts/roles/code-agent/execution-lead.md
+++ b/crates/llment/prompts/roles/code-agent/execution-lead.md
@@ -1,14 +1,18 @@
-The overall objective that we are working towards is in `objective.md`.
+The overall objective that we are working towards is in the top-level `objective.md`.
 
 You may read and understand that file, but do not edit it.
 
-The work plan is in `plan.md`.
+The work plan is in the top-level `plan.md`.
 
-The task that was most recently completed is in `task.md`. A log describing how the task was completed is in `task-log.md`. If there was no previous task, those two files will be missing.
+The task that was most recently completed is in the top-level `task.md`. A log describing how the task was completed is in the top-level `task-log.md`. If there was no previous task, those two files will be missing.
 
 As the technical lead for the project, your job now is:
-* Update plan.md and mark the corresponding work item as complete if applicable, add any relevant information based on how the task was completed.
-* Decide which task makes sense to work on next. Replace the contents of `task.md` with the specification for the new task.
-* Delete `task-log.md`.
+* Update `plan.md` (create or update if missing) and mark the corresponding work item as complete if applicable; add any relevant information based on how the task was completed.
+* Decide which task makes sense to work on next. Create or replace `task.md` with the specification for the new task, including:
+  * Scope and deliverables
+  * Acceptance criteria
+  * Expected outputs and where they should live
+  * A baseline commit SHA (e.g., the current `HEAD`) to enable reviewers to diff the work against a known starting point
+* Delete `task-log.md` if it exists.
 
 When you are done, use git to commit your changes, call agent.notify for role `eng-team` and stop.

--- a/crates/llment/prompts/roles/code-agent/reviewer.md
+++ b/crates/llment/prompts/roles/code-agent/reviewer.md
@@ -1,19 +1,25 @@
+You are a software engineer, part of a team, and have been assigned a code review.
+
 The overall objective that we are working towards is in the top-level `objective.md`.
-
 The work plan is in the top-level `plan.md`.
+The eng-team's current task is in the top-level `task.md`.
+The eng-team's work summary is in the top-level `task-log.md`. If they have done their job, all the tasks should be complete.
 
-Your peer's current task is in the top-level `task.md`.
+First, read and understand those files, but do not edit them.
 
-Your peer's work summary is in the top-level `task-log.md`. If they have done their job, all the tasks should be complete.
+The (user) eng-team has submitted their work to you for review.
+1. Ensure the eng-team has left the working directory in a clean state (git status). If not abort the review, this is a problem that they need to fix.
+2. If they said they are stuck or could not complete it, abort the review, remind them that they can take as long as necessary.
+3. Review the work and decide whether it meets the requirements of the task.
 
-You may read and understand those files, but do not edit them.
-
-Your peer has submitted their work to you for review. To review the changes:
-* If `task.md` specifies a baseline commit SHA, use it to generate the diff (e.g., `git diff <baseline_sha>..HEAD`).
+Do not rely on or trust the task log or the message from the team. Verify the changes to the codebase meet the requirements.
+* If `task.md` specifies a baseline commit SHA, use it to generate the diff (e.g., `git diff <baseline_sha>`).
 * If a baseline is not specified, derive the diff from the files in scope described in `task.md` (e.g., inspect the most recent commits touching those files and review their diffs).
+* run commands to build and test as necessary, don't run them mentally, or assume they pass
 
-Review the work and decide whether it meets the requirements of the task.
+Do not modify the code, if there are problems the eng-team will fix them.
 
-If the work is satisfactory, call agent.notify for role `execution-lead`, and request that they assign the next task; if there are any deviations from the task, summarize them, and stop.
+If the working directory is dirty or there are problems call agent.notify for role `eng-team`, and summarize any problems or changes that are necessary, and stop.
 
-Otherwise, call agent.notify for role `eng-team`, and summarize any problems or changes that are necessary, and stop.
+Otherwise, only if the work is satisfactory, call agent.notify for role `execution-lead`, and request that they assign the next task; if there are any deviations from the task, summarize them, and stop.
+

--- a/crates/llment/prompts/roles/code-agent/reviewer.md
+++ b/crates/llment/prompts/roles/code-agent/reviewer.md
@@ -1,17 +1,19 @@
-The overall objective that we are working towards is in `objective.md`.
+The overall objective that we are working towards is in the top-level `objective.md`.
 
-The work plan is in `plan.md`.
+The work plan is in the top-level `plan.md`.
 
-Your peer's current task is in `task.md`.
+Your peer's current task is in the top-level `task.md`.
 
-Your peer's work summary is in `task-log.md`. If they have done their job, all the tasks should be complete.
+Your peer's work summary is in the top-level `task-log.md`. If they have done their job, all the tasks should be complete.
 
 You may read and understand those files, but do not edit them.
 
-Your peer has submitted their work to you for review. To see them, you can use git diff against the revision in `task.md`.
+Your peer has submitted their work to you for review. To review the changes:
+* If `task.md` specifies a baseline commit SHA, use it to generate the diff (e.g., `git diff <baseline_sha>..HEAD`).
+* If a baseline is not specified, derive the diff from the files in scope described in `task.md` (e.g., inspect the most recent commits touching those files and review their diffs).
 
 Review the work and decide whether it meets the requirements of the task.
 
-If the work is satisfactory, call agent.notify for role `execution-lead`, and request that the assign the next task, if there are any deviations from the task, summarize them.
+If the work is satisfactory, call agent.notify for role `execution-lead`, and request that they assign the next task; if there are any deviations from the task, summarize them, and stop.
 
-Otherwise, call agent.notify for role `eng-team`, summarize any problems, or changes that are necessary.
+Otherwise, call agent.notify for role `eng-team`, and summarize any problems or changes that are necessary, and stop.

--- a/crates/llment/src/modes/code_agent.rs
+++ b/crates/llment/src/modes/code_agent.rs
@@ -1,0 +1,134 @@
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+use llm::{ToolInfo, mcp::McpService};
+use rmcp::{
+    ServerHandler,
+    handler::server::{router::tool::ToolRouter, tool::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    service::{RoleClient, RunningService, ServiceExt},
+    tool, tool_handler, tool_router,
+};
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use tokio::io::duplex;
+
+use super::{AgentMode, AgentModeStart, AgentModeStep};
+
+#[derive(Default)]
+struct NotifyState {
+    role: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct NotifyParams {
+    role: String,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Clone)]
+struct CodeAgentTools {
+    state: Arc<Mutex<NotifyState>>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl CodeAgentTools {
+    fn new(state: Arc<Mutex<NotifyState>>) -> Self {
+        Self {
+            state,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        name = "notify",
+        description = "Switch to another code-agent role with an optional message"
+    )]
+    fn notify(&self, Parameters(params): Parameters<NotifyParams>) -> String {
+        let mut state = self.state.lock().unwrap();
+        state.role = Some(params.role);
+        state.message = params.message;
+        "ok".into()
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for CodeAgentTools {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}
+
+pub struct CodeAgentMode {
+    current_role: String,
+    state: Arc<Mutex<NotifyState>>,
+}
+
+impl CodeAgentMode {
+    pub async fn new() -> (Self, RunningService<RoleClient, McpService>) {
+        let state = Arc::new(Mutex::new(NotifyState::default()));
+        let tools = CodeAgentTools::new(state.clone());
+        let (server_transport, client_transport) = duplex(64);
+        let (server_res, client_res) = tokio::join!(
+            tools.clone().serve(server_transport),
+            McpService {
+                prefix: "agent".into(),
+                tools: ArcSwap::new(Arc::new(vec![ToolInfo {
+                    name: "notify".into(),
+                    description: "Switch to another code-agent role with an optional message"
+                        .into(),
+                    parameters: schema_for!(NotifyParams),
+                }])),
+            }
+            .serve(client_transport)
+        );
+        let server = server_res.expect("code agent server");
+        let client_service = client_res.expect("code agent client");
+        tokio::spawn(async move {
+            let _ = server.waiting().await;
+        });
+        (
+            Self {
+                current_role: "code-agent/director".to_string(),
+                state,
+            },
+            client_service,
+        )
+    }
+}
+
+impl AgentMode for CodeAgentMode {
+    fn start(&mut self) -> AgentModeStart {
+        AgentModeStart {
+            role: Some(self.current_role.clone()),
+            prompt: Some("Let's begin.".to_string()),
+            clear_history: true,
+        }
+    }
+
+    fn step(&mut self) -> AgentModeStep {
+        let mut state = self.state.lock().unwrap();
+        if let Some(role) = state.role.take() {
+            self.current_role = format!("code-agent/{}", role);
+            AgentModeStep {
+                role: Some(self.current_role.clone()),
+                prompt: state.message.take(),
+                clear_history: false,
+                stop: false,
+            }
+        } else {
+            AgentModeStep {
+                role: Some(self.current_role.clone()),
+                prompt: Some("Please call agent.notify(role, message) to continue.".to_string()),
+                clear_history: false,
+                stop: false,
+            }
+        }
+    }
+}

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -26,13 +26,18 @@ pub async fn create_agent_mode(
     Option<RunningService<RoleClient, McpService>>,
 )> {
     match name {
+        "code-agent" => {
+            let (mode, service) = code_agent::CodeAgentMode::new().await;
+            Some((Box::new(mode), Some(service)))
+        }
         "example" => Some((Box::new(example::ExampleAgentMode::new()), None)),
         _ => None,
     }
 }
 
 pub fn available_modes() -> Vec<&'static str> {
-    vec!["example"]
+    vec!["code-agent", "example"]
 }
 
+mod code_agent;
 mod example;


### PR DESCRIPTION
## Summary
- add code-agent agent mode with MCP `agent.notify` tool to switch roles
- register `code-agent` mode and document it

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68b4db8a727c832a8870b595d530d9e6