### PR TITLE
fix(mcp-shell): handle UTF-8 boundaries in output

### DIFF
--- a/crates/mcp-shell/AGENTS.md
+++ b/crates/mcp-shell/AGENTS.md
@@ -39,6 +39,7 @@ MCP server exposing shell command execution.
 ## Constraints
 - working directory must already exist; it is not created automatically
 - `run` returns up to 10k characters of combined stdout/stderr
+- output truncation respects UTF-8 character boundaries
 - `run` waits at most 10 seconds for output or completion (limit configurable)
 - `wait` waits up to another 10 seconds for additional output (limit configurable)
 - once the 10k output limit is reached, further output is not returned

--- a/crates/mcp-shell/src/lib.rs
+++ b/crates/mcp-shell/src/lib.rs
@@ -107,7 +107,7 @@ impl CommandState {
     }
 
     fn total_len(&self) -> usize {
-        self.stdout.len() + self.stderr.len()
+        self.stdout.chars().count() + self.stderr.chars().count()
     }
 }
 
@@ -457,14 +457,14 @@ fn handle_chunk(state: &mut CommandState, is_stdout: bool, chunk: String) {
         }
         return;
     }
-    let take = remaining.min(chunk.len());
-    let part = &chunk[..take];
+    let mut chars = chunk.chars();
+    let part: String = chars.by_ref().take(remaining).collect();
     if is_stdout {
-        state.stdout.push_str(part);
+        state.stdout.push_str(&part);
     } else {
-        state.stderr.push_str(part);
+        state.stderr.push_str(&part);
     }
-    if take < chunk.len() {
+    if chars.next().is_some() {
         state.truncated = true;
         state.additional_output = true;
     }


### PR DESCRIPTION
## Summary
- count output length in characters instead of bytes
- truncate output chunks on UTF-8 boundaries to avoid slicing errors
- document UTF-8-safe truncation in mcp-shell constraints

## Testing
- `cargo test`
- `cargo test -p mcp-shell`


------
https://chatgpt.com/codex/tasks/task_e_68b5311b2934832a901d908b07a10ff3