### PR TITLE
fix(llm): consume assistant content with tool calls

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -60,6 +60,7 @@ Trait-based LLM client implementations for multiple providers.
     - provides a non-blocking `tool_names` snapshot of available tools
     - implements `ToolExecutor` for MCP calls
     - tool call chunks insert assistant messages immediately before execution
+      - any accumulated assistant content is included with the tool call
     - accumulated streamed content is appended as an assistant message after the stream completes
 - Test utilities
   - `TestProvider` implements `LlmClient`


### PR DESCRIPTION
## Summary
- ensure tool call messages include any buffered assistant content
- document new behavior in llm crate AGENTS guide

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b55ba1f774832aaa45d072f1e4b59f