### PR TITLE
feat(mcp-shell): add run status message

### DIFF
--- a/crates/mcp-shell/AGENTS.md
+++ b/crates/mcp-shell/AGENTS.md
@@ -29,7 +29,8 @@ MCP server exposing shell command execution.
     - reports if extra output was produced after the limit
   - `terminate`
     - sends SIGTERM to abort the running command
-- tool results omit false flags (`timed_out`, `output_truncated`, `additional_output`)
+- tool results return a status string: "still running, call wait or terminate" or "finished"
+- tool results omit false flags (`output_truncated`, `additional_output`)
 - tool results omit empty `stdout` and `stderr` fields
 - announces available tools to clients via MCP `list_tools`
 - parameter metadata


### PR DESCRIPTION
## Summary
- return a status string from `run` and `wait` instead of a `timed_out` flag
- document status output in mcp-shell agent specs

## Testing
- `cargo test -p mcp-shell`


------
https://chatgpt.com/codex/tasks/task_e_68b56122948c832a92a80c6d7ce8e365