### PR TITLE
feat(llment): inspect last chat message in agent step

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -86,6 +86,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - agent mode `start` and `step` may request clearing chat history before the next request
         - agent mode `start` and `step` return results with `role` and `prompt` fields
           - `prompt` set to `None` sends a request without a new user message
+        - agent mode `step` receives the last chat message in history
         - agent mode `step` can signal `stop` to exit the mode
         - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service under the `agent` prefix that is added on start and removed when switching modes or when the mode stops

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -364,8 +364,9 @@ impl Component for App {
                 }
                 Ok(Update::ResponseComplete) => {
                     self.state = ConversationState::Idle;
+                    let last_message = { self.chat_history.lock().unwrap().last().cloned() };
                     let step = if let Some(mode) = self.mode.as_mut() {
-                        Some(mode.step())
+                        Some(mode.step(last_message.as_ref()))
                     } else {
                         None
                     };

--- a/crates/llment/src/modes/example.rs
+++ b/crates/llment/src/modes/example.rs
@@ -20,7 +20,7 @@ impl AgentMode for ExampleAgentMode {
         }
     }
 
-    fn step(&mut self) -> AgentModeStep {
+    fn step(&mut self, _last_message: Option<&llm::ChatMessage>) -> AgentModeStep {
         if self.stage == 1 {
             self.stage = 2;
             AgentModeStep {

--- a/crates/llment/src/modes/mod.rs
+++ b/crates/llment/src/modes/mod.rs
@@ -1,4 +1,4 @@
-use llm::mcp::McpService;
+use llm::{ChatMessage, mcp::McpService};
 use rmcp::service::{RoleClient, RunningService};
 
 pub struct AgentModeStart {
@@ -16,7 +16,7 @@ pub struct AgentModeStep {
 
 pub trait AgentMode: Send {
     fn start(&mut self) -> AgentModeStart;
-    fn step(&mut self) -> AgentModeStep;
+    fn step(&mut self, last_message: Option<&ChatMessage>) -> AgentModeStep;
 }
 
 pub async fn create_agent_mode(


### PR DESCRIPTION
## Summary
- pass last chat message to AgentMode::step
- ignore thinking-only responses in CodeAgentMode
- document agent mode step message access

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5766ecd4c832aa5eb02fbdc914520