### PR TITLE
refactor(llm): extract GptOss prompt helper and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "async-openai",
  "async-trait",
  "clap",
+ "futures-util",
  "gemini-rs",
  "ollama-rs",
  "openai-harmony",

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -28,7 +28,7 @@ Trait-based LLM client implementations for multiple providers.
   - `LlmClient` trait streams chat responses and lists supported model names
 - implementations for Ollama, OpenAI, GptOss, and Gemini
 - GptOss client uses v1/completions with Harmony format for `gpt-oss`
-- GptOss client builds prompts via helper that handles thinking or final-prefill when last history message is from assistant
+- GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -29,6 +29,7 @@ Trait-based LLM client implementations for multiple providers.
 - implementations for Ollama, OpenAI, GptOss, and Gemini
 - GptOss client uses v1/completions with Harmony format for `gpt-oss`
 - GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
+  - streaming parser is primed with prefill tokens so continuation in the same channel is captured
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -29,6 +29,7 @@ Trait-based LLM client implementations for multiple providers.
 - implementations for Ollama, OpenAI, GptOss, and Gemini
 - GptOss client uses v1/completions with Harmony format for `gpt-oss`
 - GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
+  - analysis segments preceding final content are omitted from prompts
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
 - Provider selection
   - `Provider` enum lists supported backends

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -28,6 +28,7 @@ Trait-based LLM client implementations for multiple providers.
   - `LlmClient` trait streams chat responses and lists supported model names
 - implementations for Ollama, OpenAI, GptOss, and Gemini
 - GptOss client uses v1/completions with Harmony format for `gpt-oss`
+- GptOss client builds prompts via helper that handles thinking or final-prefill when last history message is from assistant
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -29,7 +29,7 @@ Trait-based LLM client implementations for multiple providers.
 - implementations for Ollama, OpenAI, GptOss, and Gemini
 - GptOss client uses v1/completions with Harmony format for `gpt-oss`
 - GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
-  - analysis segments preceding final content are omitted from prompts
+  - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
 - Provider selection
   - `Provider` enum lists supported backends

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -31,6 +31,7 @@ Trait-based LLM client implementations for multiple providers.
 - GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
+  - tool calls render in the commentary channel with constrained JSON, and tool responses map to tool role messages
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -31,7 +31,8 @@ Trait-based LLM client implementations for multiple providers.
 - GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
-  - tool calls render in the commentary channel with constrained JSON, and tool responses map to tool role messages
+  - tool calls render in the commentary channel with constrained JSON
+  - tool responses map to tool role messages in the commentary channel addressed to the assistant
 - Provider selection
   - `Provider` enum lists supported backends
   - `client_from` builds a client for the given provider and model

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -9,6 +9,7 @@ arc-swap = "1.7.1"
 async-openai = { version = "0.29.0", features = ["byot"] }
 async-trait = "0.1.88"
 clap = { version = "4.5.43", features = ["derive"] }
+futures-util = "0.3.31"
 gemini-rs = { git = "https://github.com/dstoc/gemini-rs", branch = "include-thoughts", version = "2.0.0" }
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
 openai-harmony = "0.0.3"

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -293,10 +293,10 @@ mod tests {
         );
         let (prompt, prefill_tokens) = build_prompt(&encoding, &request).unwrap();
         assert!(prefill_tokens.is_some());
-        assert_eq!(
-            prompt,
+        assert!(prompt.contains("<|start|>system<|message|>"));
+        assert!(prompt.ends_with(
             "<|start|>user<|message|>Hi<|end|><|start|>assistant<|channel|>analysis<|message|>ponder"
-        );
+        ));
     }
 
     #[test]
@@ -311,10 +311,10 @@ mod tests {
         );
         let (prompt, prefill_tokens) = build_prompt(&encoding, &request).unwrap();
         assert!(prefill_tokens.is_some());
-        assert_eq!(
-            prompt,
+        assert!(prompt.contains("<|start|>system<|message|>"));
+        assert!(prompt.ends_with(
             "<|start|>user<|message|>Hi<|end|><|start|>assistant<|channel|>final<|message|>Hello"
-        );
+        ));
     }
 
     #[test]
@@ -339,18 +339,16 @@ mod tests {
         );
         let (prompt, prefill_tokens) = build_prompt(&encoding, &request).unwrap();
         assert!(prefill_tokens.is_none());
-        assert_eq!(
-            prompt,
-            concat!(
-                "<|start|>user<|message|>Hi<|end|>",
-                "<|start|>assistant<|channel|>analysis<|message|>ponder<|end|>",
-                "<|start|>assistant<|channel|>final<|message|>Hello<|end|>",
-                "<|start|>user<|message|>How are you?<|end|>",
-                "<|start|>assistant<|channel|>analysis<|message|>think<|end|>",
-                "<|start|>assistant<|channel|>final<|message|>I'm good<|end|>",
-                "<|start|>assistant"
-            )
-        );
+        assert!(prompt.contains("<|start|>system<|message|>"));
+        assert!(prompt.ends_with(concat!(
+            "<|start|>user<|message|>Hi<|end|>",
+            "<|start|>assistant<|channel|>analysis<|message|>ponder<|end|>",
+            "<|start|>assistant<|channel|>final<|message|>Hello<|end|>",
+            "<|start|>user<|message|>How are you?<|end|>",
+            "<|start|>assistant<|channel|>analysis<|message|>think<|end|>",
+            "<|start|>assistant<|channel|>final<|message|>I'm good<|end|>",
+            "<|start|>assistant"
+        )));
     }
 
     #[test]

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -270,10 +270,7 @@ mod tests {
 
     #[test]
     fn prefill_with_thinking() {
-        let Ok(encoding) = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss) else {
-            eprintln!("skipping: failed to load encoding");
-            return;
-        };
+        let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
         let request = ChatMessageRequest::new(
             "gpt-oss".into(),
             vec![
@@ -294,10 +291,7 @@ mod tests {
 
     #[test]
     fn prefill_with_content() {
-        let Ok(encoding) = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss) else {
-            eprintln!("skipping: failed to load encoding");
-            return;
-        };
+        let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
         let request = ChatMessageRequest::new(
             "gpt-oss".into(),
             vec![
@@ -309,6 +303,41 @@ mod tests {
         assert_eq!(
             prompt,
             "<|start|>user<|message|>Hi<|end|><|start|>assistant<|channel|>final<|message|>Hello"
+        );
+    }
+
+    #[test]
+    fn thinking_and_content_history() {
+        let encoding = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+        let request = ChatMessageRequest::new(
+            "gpt-oss".into(),
+            vec![
+                ChatMessage::user("Hi".into()),
+                ChatMessage::Assistant(AssistantMessage {
+                    content: "Hello".into(),
+                    tool_calls: vec![],
+                    thinking: Some("ponder".into()),
+                }),
+                ChatMessage::user("How are you?".into()),
+                ChatMessage::Assistant(AssistantMessage {
+                    content: "I'm good".into(),
+                    tool_calls: vec![],
+                    thinking: Some("think".into()),
+                }),
+            ],
+        );
+        let prompt = build_prompt(&encoding, &request).unwrap();
+        assert_eq!(
+            prompt,
+            concat!(
+                "<|start|>user<|message|>Hi<|end|>",
+                "<|start|>assistant<|channel|>analysis<|message|>ponder<|end|>",
+                "<|start|>assistant<|channel|>final<|message|>Hello<|end|>",
+                "<|start|>user<|message|>How are you?<|end|>",
+                "<|start|>assistant<|channel|>analysis<|message|>think<|end|>",
+                "<|start|>assistant<|channel|>final<|message|>I'm good<|end|>",
+                "<|start|>assistant"
+            )
         );
     }
 }

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -387,11 +387,15 @@ mod tests {
         assert!(prefill_tokens.is_none());
         let args = json!({"a": 2, "b": 2}).to_string();
         let result = json!({"sum": 4}).to_string();
-        assert!(prompt.contains("<|channel|>commentary"));
-        assert!(prompt.contains("functions.add"));
-        assert!(prompt.contains(&args));
-        assert!(prompt.contains(&result));
-        assert!(prompt.ends_with("<|start|>assistant"));
+        let expected_tail = format!(
+            concat!(
+                "<|start|>assistant to=functions.add<|channel|>commentary <|constrain|>json<|message|>{args}<|call|>",
+                "<|start|>functions.add<|message|>{result}<|end|><|start|>assistant"
+            ),
+            args = args,
+            result = result
+        );
+        assert!(prompt.ends_with(&expected_tail));
     }
 
     #[test]

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -138,10 +138,14 @@ fn build_prompt(
                     Value::String(s) => s.clone(),
                     v => v.to_string(),
                 };
-                convo_msgs.push(Message::from_author_and_content(
-                    Author::new(Role::Tool, format!("functions.{}", t.tool_name)),
-                    content_str,
-                ));
+                convo_msgs.push(
+                    Message::from_author_and_content(
+                        Author::new(Role::Tool, format!("functions.{}", t.tool_name)),
+                        content_str,
+                    )
+                    .with_channel("commentary")
+                    .with_recipient("assistant"),
+                );
             }
             ChatMessage::System(_) => {}
         }
@@ -390,7 +394,7 @@ mod tests {
         let expected_tail = format!(
             concat!(
                 "<|start|>assistant to=functions.add<|channel|>commentary <|constrain|>json<|message|>{args}<|call|>",
-                "<|start|>functions.add<|message|>{result}<|end|><|start|>assistant"
+                "<|start|>functions.add to=assistant<|channel|>commentary<|message|>{result}<|end|><|start|>assistant"
             ),
             args = args,
             result = result


### PR DESCRIPTION
## Summary
- build a helper to render chat history into a Harmony prompt with optional assistant prefill
- refactor GptOss client to use the helper
- add tests covering thinking-only and content-only prefill cases

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b67e931e64832abe7aeac61b166a36