### PR TITLE
fix(llm): report full tool name on invalid prefix

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -67,6 +67,7 @@ Trait-based LLM client implementations for multiple providers.
     - exposes merged `tool_infos` from all services
     - provides a non-blocking `tool_names` snapshot of available tools
     - implements `ToolExecutor` for MCP calls
+      - unrecognized or unprefixed tool names return "{name} is not a valid tool name"
     - tool call chunks insert assistant messages immediately before execution
       - accumulated assistant content is flushed as a separate assistant message
       - the tool-call assistant message carries empty `content` with `tool_calls` populated

--- a/crates/llm/src/mcp.rs
+++ b/crates/llm/src/mcp.rs
@@ -102,12 +102,12 @@ impl ToolExecutor for McpContext {
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let (prefix, tool_name) = name
             .split_once('.')
-            .ok_or_else(|| format!("Tool {name} missing prefix"))?;
+            .ok_or_else(|| format!("{name} is not a valid tool name"))?;
         let peer = {
             let services = self.services.lock().unwrap();
             let svc = services
                 .get(prefix)
-                .ok_or_else(|| format!("Service {prefix} not found"))?;
+                .ok_or_else(|| format!("{name} is not a valid tool name"))?;
             svc.peer().clone()
         };
         let result = peer


### PR DESCRIPTION
## Summary
- return "{name} is not a valid tool name" when tool calls lack or use unknown prefix
- document error handling for unprefixed or unknown tool names

Fixes #154 

## Testing
- `cargo test -p llm`

------
https://chatgpt.com/codex/tasks/task_e_68b6dec7dc44832abb4b1101459f8719