### PR TITLE
refactor(llm): use enums for response types

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -48,8 +48,10 @@ Trait-based LLM client implementations for multiple providers.
 - Chat message, request, and response types serialize to and from JSON
   - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses
-  - `ResponseChunk` is an enum of `Thinking`, `ToolCalls`, `Content`, `Usage`, or `Done`
-  - chunks stream thinking, tool calls, and content first, followed by optional `Usage` then `Done`
+  - `ResponseChunk` is an enum of `Thinking`, `ToolCall`, `Content`, `Usage`, or `Done`
+  - thinking, tool calls, and content stream first, followed by optional usage then done
+  - usage chunks carry `input_tokens` and `output_tokens`
+  - each tool call chunk holds a single `ToolCall` and is repeated as needed
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
   - OpenAI client parses `reasoning_content` from streamed responses into thinking text
 - Tool orchestration

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -48,10 +48,12 @@ Trait-based LLM client implementations for multiple providers.
 - Chat message, request, and response types serialize to and from JSON
   - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses
-  - `ResponseChunk` is an enum of `Thinking`, `ToolCall`, `Content`, `Usage`, or `Done`
-  - thinking, tool calls, and content stream first, followed by optional usage then done
+  - `ResponseMessage` is an enum of `Thinking`, `ToolCall`, or `Content`
+  - messages stream in order: thinking, tool calls, then content
+  - `ResponseChunk` is an enum of `Message`, `Usage`, or `Done`
   - usage chunks carry `input_tokens` and `output_tokens`
-  - each tool call chunk holds a single `ToolCall` and is repeated as needed
+  - each `Message::ToolCall` chunk holds a single `ToolCall` and is repeated as needed
+  - thinking, tool calls, and content stream first, followed by optional usage then `Done`
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
   - OpenAI client parses `reasoning_content` from streamed responses into thinking text
 - Tool orchestration

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -48,11 +48,9 @@ Trait-based LLM client implementations for multiple providers.
 - Chat message, request, and response types serialize to and from JSON
   - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses
-  - `ResponseMessage` is an enum of `Thinking`, `ToolCall`, or `Content`
-  - messages stream in order: thinking, tool calls, then content
-  - `ResponseChunk` is an enum of `Message`, `Usage`, or `Done`
+  - `ResponseChunk` is an enum of `Thinking`, `ToolCall`, `Content`, `Usage`, or `Done`
   - usage chunks carry `input_tokens` and `output_tokens`
-  - each `Message::ToolCall` chunk holds a single `ToolCall` and is repeated as needed
+  - tool call chunks hold a single `ToolCall` and repeat as needed
   - thinking, tool calls, and content stream first, followed by optional usage then `Done`
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
   - OpenAI client parses `reasoning_content` from streamed responses into thinking text

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -48,7 +48,8 @@ Trait-based LLM client implementations for multiple providers.
 - Chat message, request, and response types serialize to and from JSON
   - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses
-  - chunks include optional content, tool calls, optional thinking text, and usage metrics on the final chunk
+  - `ResponseChunk` is an enum of `Thinking`, `ToolCalls`, `Content`, `Usage`, or `Done`
+  - chunks stream thinking, tool calls, and content first, followed by optional `Usage` then `Done`
   - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
   - OpenAI client parses `reasoning_content` from streamed responses into thinking text
 - Tool orchestration

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -12,8 +12,8 @@ use gemini_rs::{
 use uuid::Uuid;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
-    ToolCall, to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
+    to_openapi_schema,
 };
 
 pub struct GeminiClient {
@@ -172,15 +172,13 @@ impl LlmClient for GeminiClient {
                     let mut out: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> =
                         Vec::new();
                     if let Some(t) = thinking {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(t))));
+                        out.push(Ok(ResponseChunk::Thinking(t)));
                     }
                     for tc in tool_calls {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
+                        out.push(Ok(ResponseChunk::ToolCall(tc)));
                     }
                     if !content_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
-                            content_acc,
-                        ))));
+                        out.push(Ok(ResponseChunk::Content(content_acc)));
                     }
                     if let Some((input_tokens, output_tokens)) = usage {
                         out.push(Ok(ResponseChunk::Usage {

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -12,8 +12,8 @@ use gemini_rs::{
 use uuid::Uuid;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
-    to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
+    ToolCall, to_openapi_schema,
 };
 
 pub struct GeminiClient {
@@ -172,13 +172,15 @@ impl LlmClient for GeminiClient {
                     let mut out: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> =
                         Vec::new();
                     if let Some(t) = thinking {
-                        out.push(Ok(ResponseChunk::Thinking(t)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(t))));
                     }
                     for tc in tool_calls {
-                        out.push(Ok(ResponseChunk::ToolCall(tc)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
                     }
                     if !content_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Content(content_acc)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
+                            content_acc,
+                        ))));
                     }
                     if let Some((input_tokens, output_tokens)) = usage {
                         out.push(Ok(ResponseChunk::Usage {

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
-    ToolCall, to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
+    to_openapi_schema,
 };
 use async_openai::{Client, config::OpenAIConfig, types::*};
 use async_trait::async_trait;
@@ -222,14 +222,10 @@ impl LlmClient for GptOssClient {
                                 if !delta.is_empty() && parser.current_recipient().is_none() {
                                     match parser.current_channel().as_deref() {
                                         Some("analysis") => {
-                                            out.push(Ok(ResponseChunk::Message(
-                                                ResponseMessage::Thinking(delta),
-                                            )));
+                                            out.push(Ok(ResponseChunk::Thinking(delta)));
                                         }
                                         Some("final") => {
-                                            out.push(Ok(ResponseChunk::Message(
-                                                ResponseMessage::Content(delta),
-                                            )));
+                                            out.push(Ok(ResponseChunk::Content(delta)));
                                         }
                                         _ => {}
                                     }
@@ -251,13 +247,11 @@ impl LlmClient for GptOssClient {
                                 {
                                     let args: Value =
                                         serde_json::from_str(text).unwrap_or(Value::Null);
-                                    out.push(Ok(ResponseChunk::Message(
-                                        ResponseMessage::ToolCall(ToolCall {
-                                            id: Uuid::new_v4().to_string(),
-                                            name: name.to_string(),
-                                            arguments: args,
-                                        }),
-                                    )));
+                                    out.push(Ok(ResponseChunk::ToolCall(ToolCall {
+                                        id: Uuid::new_v4().to_string(),
+                                        name: name.to_string(),
+                                        arguments: args,
+                                    })));
                                 }
                             }
                         }

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
-    to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
+    ToolCall, to_openapi_schema,
 };
 use async_openai::{Client, config::OpenAIConfig, types::*};
 use async_trait::async_trait;
@@ -222,10 +222,14 @@ impl LlmClient for GptOssClient {
                                 if !delta.is_empty() && parser.current_recipient().is_none() {
                                     match parser.current_channel().as_deref() {
                                         Some("analysis") => {
-                                            out.push(Ok(ResponseChunk::Thinking(delta)));
+                                            out.push(Ok(ResponseChunk::Message(
+                                                ResponseMessage::Thinking(delta),
+                                            )));
                                         }
                                         Some("final") => {
-                                            out.push(Ok(ResponseChunk::Content(delta)));
+                                            out.push(Ok(ResponseChunk::Message(
+                                                ResponseMessage::Content(delta),
+                                            )));
                                         }
                                         _ => {}
                                     }
@@ -247,11 +251,13 @@ impl LlmClient for GptOssClient {
                                 {
                                     let args: Value =
                                         serde_json::from_str(text).unwrap_or(Value::Null);
-                                    out.push(Ok(ResponseChunk::ToolCall(ToolCall {
-                                        id: Uuid::new_v4().to_string(),
-                                        name: name.to_string(),
-                                        arguments: args,
-                                    })));
+                                    out.push(Ok(ResponseChunk::Message(
+                                        ResponseMessage::ToolCall(ToolCall {
+                                            id: Uuid::new_v4().to_string(),
+                                            name: name.to_string(),
+                                            arguments: args,
+                                        }),
+                                    )));
                                 }
                             }
                         }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -198,17 +198,14 @@ pub fn client_from(
 }
 
 #[derive(Debug, Clone)]
-pub struct Usage {
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-}
-
-#[derive(Debug, Clone)]
 pub enum ResponseChunk {
-    Thinking { thinking: String },
-    ToolCalls { tool_calls: Vec<ToolCall> },
-    Content { content: String },
-    Usage { usage: Usage },
+    Thinking(String),
+    ToolCall(ToolCall),
+    Content(String),
+    Usage {
+        input_tokens: u32,
+        output_tokens: u32,
+    },
     Done,
 }
 

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -198,10 +198,15 @@ pub fn client_from(
 }
 
 #[derive(Debug, Clone)]
-pub enum ResponseChunk {
+pub enum ResponseMessage {
     Thinking(String),
     ToolCall(ToolCall),
     Content(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum ResponseChunk {
+    Message(ResponseMessage),
     Usage {
         input_tokens: u32,
         output_tokens: u32,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -197,28 +197,19 @@ pub fn client_from(
     })
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ResponseMessage {
-    #[serde(default, skip_serializing_if = "option_string_is_empty")]
-    pub content: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tool_calls: Vec<ToolCall>,
-    #[serde(default, skip_serializing_if = "option_string_is_empty")]
-    pub thinking: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Usage {
     pub input_tokens: u32,
     pub output_tokens: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ResponseChunk {
-    pub message: ResponseMessage,
-    pub done: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage: Option<Usage>,
+#[derive(Debug, Clone)]
+pub enum ResponseChunk {
+    Thinking { thinking: String },
+    ToolCalls { tool_calls: Vec<ToolCall> },
+    Content { content: String },
+    Usage { usage: Usage },
+    Done,
 }
 
 pub type ChatStream =

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -198,15 +198,10 @@ pub fn client_from(
 }
 
 #[derive(Debug, Clone)]
-pub enum ResponseMessage {
+pub enum ResponseChunk {
     Thinking(String),
     ToolCall(ToolCall),
     Content(String),
-}
-
-#[derive(Debug, Clone)]
-pub enum ResponseChunk {
-    Message(ResponseMessage),
     Usage {
         input_tokens: u32,
         output_tokens: u32,

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -20,9 +20,7 @@ use ollama_rs::{
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall, Usage,
-};
+use super::{ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall};
 
 pub struct OllamaClient {
     inner: Ollama,
@@ -108,7 +106,7 @@ impl LlmClient for OllamaClient {
                 let mut out: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> = Vec::new();
                 if !r.message.thinking.clone().unwrap_or_default().is_empty() {
                     if let Some(thinking) = r.message.thinking.clone() {
-                        out.push(Ok(ResponseChunk::Thinking { thinking }));
+                        out.push(Ok(ResponseChunk::Thinking(thinking)));
                     }
                 }
                 let tool_calls: Vec<ToolCall> = r
@@ -121,21 +119,17 @@ impl LlmClient for OllamaClient {
                         arguments: tc.function.arguments,
                     })
                     .collect();
-                if !tool_calls.is_empty() {
-                    out.push(Ok(ResponseChunk::ToolCalls { tool_calls }));
+                for tc in tool_calls {
+                    out.push(Ok(ResponseChunk::ToolCall(tc)));
                 }
                 if !r.message.content.is_empty() {
-                    out.push(Ok(ResponseChunk::Content {
-                        content: r.message.content,
-                    }));
+                    out.push(Ok(ResponseChunk::Content(r.message.content)));
                 }
                 if r.done {
                     if let Some(f) = r.final_data.as_ref() {
                         out.push(Ok(ResponseChunk::Usage {
-                            usage: Usage {
-                                input_tokens: f.prompt_eval_count as u32,
-                                output_tokens: f.eval_count as u32,
-                            },
+                            input_tokens: f.prompt_eval_count as u32,
+                            output_tokens: f.eval_count as u32,
                         }));
                     }
                     out.push(Ok(ResponseChunk::Done));

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -20,10 +20,7 @@ use ollama_rs::{
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
-    ToolCall,
-};
+use super::{ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall};
 
 pub struct OllamaClient {
     inner: Ollama,
@@ -109,9 +106,7 @@ impl LlmClient for OllamaClient {
                 let mut out: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> = Vec::new();
                 if !r.message.thinking.clone().unwrap_or_default().is_empty() {
                     if let Some(thinking) = r.message.thinking.clone() {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(
-                            thinking,
-                        ))));
+                        out.push(Ok(ResponseChunk::Thinking(thinking)));
                     }
                 }
                 let tool_calls: Vec<ToolCall> = r
@@ -125,12 +120,10 @@ impl LlmClient for OllamaClient {
                     })
                     .collect();
                 for tc in tool_calls {
-                    out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
+                    out.push(Ok(ResponseChunk::ToolCall(tc)));
                 }
                 if !r.message.content.is_empty() {
-                    out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
-                        r.message.content,
-                    ))));
+                    out.push(Ok(ResponseChunk::Content(r.message.content)));
                 }
                 if r.done {
                     if let Some(f) = r.final_data.as_ref() {

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -20,7 +20,10 @@ use ollama_rs::{
 use serde_json::Value;
 use uuid::Uuid;
 
-use super::{ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall};
+use super::{
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
+    ToolCall,
+};
 
 pub struct OllamaClient {
     inner: Ollama,
@@ -106,7 +109,9 @@ impl LlmClient for OllamaClient {
                 let mut out: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> = Vec::new();
                 if !r.message.thinking.clone().unwrap_or_default().is_empty() {
                     if let Some(thinking) = r.message.thinking.clone() {
-                        out.push(Ok(ResponseChunk::Thinking(thinking)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(
+                            thinking,
+                        ))));
                     }
                 }
                 let tool_calls: Vec<ToolCall> = r
@@ -120,10 +125,12 @@ impl LlmClient for OllamaClient {
                     })
                     .collect();
                 for tc in tool_calls {
-                    out.push(Ok(ResponseChunk::ToolCall(tc)));
+                    out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
                 }
                 if !r.message.content.is_empty() {
-                    out.push(Ok(ResponseChunk::Content(r.message.content)));
+                    out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
+                        r.message.content,
+                    ))));
                 }
                 if r.done {
                     if let Some(f) = r.final_data.as_ref() {

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
-    to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
+    ToolCall, to_openapi_schema,
 };
 use async_openai::{Client, config::OpenAIConfig, types::*};
 use async_trait::async_trait;
@@ -231,13 +231,17 @@ impl LlmClient for OpenAiClient {
                         None
                     };
                     if !thinking_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Thinking(thinking_acc)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(
+                            thinking_acc,
+                        ))));
                     }
                     for tc in tool_calls {
-                        out.push(Ok(ResponseChunk::ToolCall(tc)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
                     }
                     if !content_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Content(content_acc)));
+                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
+                            content_acc,
+                        ))));
                     }
                     if let Some((input_tokens, output_tokens)) = usage {
                         out.push(Ok(ResponseChunk::Usage {

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ResponseMessage,
-    ToolCall, to_openapi_schema,
+    ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
+    to_openapi_schema,
 };
 use async_openai::{Client, config::OpenAIConfig, types::*};
 use async_trait::async_trait;
@@ -231,17 +231,13 @@ impl LlmClient for OpenAiClient {
                         None
                     };
                     if !thinking_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Thinking(
-                            thinking_acc,
-                        ))));
+                        out.push(Ok(ResponseChunk::Thinking(thinking_acc)));
                     }
                     for tc in tool_calls {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::ToolCall(tc))));
+                        out.push(Ok(ResponseChunk::ToolCall(tc)));
                     }
                     if !content_acc.is_empty() {
-                        out.push(Ok(ResponseChunk::Message(ResponseMessage::Content(
-                            content_acc,
-                        ))));
+                        out.push(Ok(ResponseChunk::Content(content_acc)));
                     }
                     if let Some((input_tokens, output_tokens)) = usage {
                         out.push(Ok(ResponseChunk::Usage {

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -52,7 +52,7 @@ impl LlmClient for TestProvider {
 mod tests {
     use super::*;
     use crate::tools::{ToolExecutor, run_tool_loop};
-    use crate::{ChatMessage, ToolCall};
+    use crate::{ChatMessage, ResponseMessage, ToolCall};
     use serde_json::Value;
     use std::sync::{Arc, Mutex};
 
@@ -73,15 +73,15 @@ mod tests {
     async fn captures_requests_and_iterates() {
         let client = Arc::new(TestProvider::new());
         client.enqueue(vec![
-            ResponseChunk::ToolCall(ToolCall {
+            ResponseChunk::Message(ResponseMessage::ToolCall(ToolCall {
                 id: "call-1".into(),
                 name: "test".into(),
                 arguments: Value::Null,
-            }),
+            })),
             ResponseChunk::Done,
         ]);
         client.enqueue(vec![
-            ResponseChunk::Content("final".into()),
+            ResponseChunk::Message(ResponseMessage::Content("final".into())),
             ResponseChunk::Done,
         ]);
         let exec = Arc::new(DummyExec);

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -52,7 +52,7 @@ impl LlmClient for TestProvider {
 mod tests {
     use super::*;
     use crate::tools::{ToolExecutor, run_tool_loop};
-    use crate::{ChatMessage, ResponseMessage, ToolCall};
+    use crate::{ChatMessage, ToolCall};
     use serde_json::Value;
     use std::sync::{Arc, Mutex};
 
@@ -73,15 +73,15 @@ mod tests {
     async fn captures_requests_and_iterates() {
         let client = Arc::new(TestProvider::new());
         client.enqueue(vec![
-            ResponseChunk::Message(ResponseMessage::ToolCall(ToolCall {
+            ResponseChunk::ToolCall(ToolCall {
                 id: "call-1".into(),
                 name: "test".into(),
                 arguments: Value::Null,
-            })),
+            }),
             ResponseChunk::Done,
         ]);
         client.enqueue(vec![
-            ResponseChunk::Message(ResponseMessage::Content("final".into())),
+            ResponseChunk::Content("final".into()),
             ResponseChunk::Done,
         ]);
         let exec = Arc::new(DummyExec);

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -73,19 +73,15 @@ mod tests {
     async fn captures_requests_and_iterates() {
         let client = Arc::new(TestProvider::new());
         client.enqueue(vec![
-            ResponseChunk::ToolCalls {
-                tool_calls: vec![ToolCall {
-                    id: "call-1".into(),
-                    name: "test".into(),
-                    arguments: Value::Null,
-                }],
-            },
+            ResponseChunk::ToolCall(ToolCall {
+                id: "call-1".into(),
+                name: "test".into(),
+                arguments: Value::Null,
+            }),
             ResponseChunk::Done,
         ]);
         client.enqueue(vec![
-            ResponseChunk::Content {
-                content: "final".into(),
-            },
+            ResponseChunk::Content("final".into()),
             ResponseChunk::Done,
         ]);
         let exec = Arc::new(DummyExec);

--- a/crates/llm/src/tools.rs
+++ b/crates/llm/src/tools.rs
@@ -13,8 +13,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    AssistantMessage, ChatMessage, ChatMessageRequest, LlmClient, ResponseChunk, ResponseMessage,
-    ToolCall,
+    AssistantMessage, ChatMessage, ChatMessageRequest, LlmClient, ResponseChunk, ToolCall,
 };
 
 #[async_trait]
@@ -79,21 +78,21 @@ pub async fn run_tool_loop(
             let mut done = false;
             let mut tool_calls: Vec<ToolCall> = Vec::new();
             match &chunk {
-                ResponseChunk::Message(ResponseMessage::Content(content)) => {
+                ResponseChunk::Content(content) => {
                     if !content.is_empty() {
                         assistant_content
                             .get_or_insert_with(String::new)
                             .push_str(content);
                     }
                 }
-                ResponseChunk::Message(ResponseMessage::Thinking(thinking)) => {
+                ResponseChunk::Thinking(thinking) => {
                     if !thinking.is_empty() {
                         assistant_thinking
                             .get_or_insert_with(String::new)
                             .push_str(thinking);
                     }
                 }
-                ResponseChunk::Message(ResponseMessage::ToolCall(tc)) => {
+                ResponseChunk::ToolCall(tc) => {
                     tool_calls.push(tc.clone());
                 }
                 ResponseChunk::Usage { .. } => {}
@@ -212,22 +211,16 @@ mod tests {
             *calls += 1;
             let stream: Vec<Result<ResponseChunk, Box<dyn Error + Send + Sync>>> = match *calls {
                 1 => vec![
-                    Ok(ResponseChunk::Message(ResponseMessage::Content(
-                        "first".into(),
-                    ))),
-                    Ok(ResponseChunk::Message(ResponseMessage::ToolCall(
-                        crate::ToolCall {
-                            id: "call-1".into(),
-                            name: "test".into(),
-                            arguments: Value::Null,
-                        },
-                    ))),
+                    Ok(ResponseChunk::Content("first".into())),
+                    Ok(ResponseChunk::ToolCall(crate::ToolCall {
+                        id: "call-1".into(),
+                        name: "test".into(),
+                        arguments: Value::Null,
+                    })),
                     Ok(ResponseChunk::Done),
                 ],
                 2 => vec![
-                    Ok(ResponseChunk::Message(ResponseMessage::Content(
-                        "final".into(),
-                    ))),
+                    Ok(ResponseChunk::Content("final".into())),
                     Ok(ResponseChunk::Done),
                 ],
                 _ => vec![],
@@ -298,9 +291,7 @@ mod tests {
         while let Ok(ev) = rx.try_recv() {
             match ev {
                 ToolEvent::ToolResult { .. } => saw_tool = true,
-                ToolEvent::Chunk(ResponseChunk::Message(ResponseMessage::Content(content)))
-                    if content == "final" =>
-                {
+                ToolEvent::Chunk(ResponseChunk::Content(content)) if content == "final" => {
                     saw_final = true
                 }
                 _ => {}

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use crossterm::event::Event;
 use llm::{
-    ChatMessage, ChatMessageRequest, Provider, ResponseChunk, ResponseMessage,
+    ChatMessage, ChatMessageRequest, Provider, ResponseChunk,
     mcp::{McpContext, McpService},
     tools::{ToolEvent, ToolExecutor, tool_event_stream},
 };
@@ -187,19 +187,19 @@ impl App {
     fn handle_tool_event(&mut self, ev: ToolEvent) {
         match ev {
             ToolEvent::Chunk(chunk) => match chunk {
-                ResponseChunk::Message(ResponseMessage::Thinking(thinking)) => {
+                ResponseChunk::Thinking(thinking) => {
                     self.state = ConversationState::Thinking;
                     let _ = self.model.needs_redraw.send(true);
                     self.conversation.append_thinking(&thinking);
                 }
-                ResponseChunk::Message(ResponseMessage::Content(content)) => {
+                ResponseChunk::Content(content) => {
                     if !content.is_empty() {
                         self.state = ConversationState::Responding;
                         let _ = self.model.needs_redraw.send(true);
                         self.conversation.append_response(&content);
                     }
                 }
-                ResponseChunk::Message(ResponseMessage::ToolCall(_)) => {}
+                ResponseChunk::ToolCall(_) => {}
                 ResponseChunk::Usage {
                     input_tokens,
                     output_tokens,

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{Event, MouseButton, MouseEventKind};
-use llm::{ChatMessage, Usage};
+use llm::ChatMessage;
 use ratatui::{Frame, layout::Rect};
 use serde_json::to_string;
 use std::collections::HashMap;
@@ -277,9 +277,9 @@ impl Conversation {
         }
     }
 
-    pub fn set_usage(&mut self, usage: Usage) {
+    pub fn set_usage(&mut self, input_tokens: u32, output_tokens: u32) {
         if let Some(Node::Assistant(block)) = self.items.last_mut() {
-            block.set_usage(usage.input_tokens, usage.output_tokens);
+            block.set_usage(input_tokens, output_tokens);
         }
     }
 


### PR DESCRIPTION
## Summary
- merge response message variants into `ResponseChunk` and drop `ResponseMessage`
- remove needless serialization and boolean flag from `Done`
- update providers, tooling, and tests for unified chunk enum

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b6f8807f40832a8b115114023e16b1