### PR TITLE
chore(llm): use openai-harmony v0.0.4 from GitHub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,9 +2323,8 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openai-harmony"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b7fd6b7d01a317c58d85a22b7cc314e14a2fef0dfdb93b819738d09caece16"
+version = "0.0.4"
+source = "git+https://github.com/openai/harmony?tag=v0.0.4#72079ca4971f326dddcd5ff62bfb7e2fff37a07a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -14,7 +14,7 @@ Trait-based LLM client implementations for multiple providers.
   - communicate with Ollama using streaming and tools
 - async-openai
   - connect to OpenAI models
-- openai-harmony
+- openai-harmony (v0.0.4, git tag)
   - render Harmony prompts and parse responses for gpt-oss
 - gemini-rs
   - connect to Gemini models

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.43", features = ["derive"] }
 futures-util = "0.3.31"
 gemini-rs = { git = "https://github.com/dstoc/gemini-rs", branch = "include-thoughts", version = "2.0.0" }
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
-openai-harmony = "0.0.3"
+openai-harmony = { git = "https://github.com/openai/harmony", tag = "v0.0.4", version = "0.0.4" }
 rmcp = { version = "0.4.0", features = ["client", "transport-child-process"] }
 schemars = "1.0.4"
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
## Summary
- pull openai-harmony from the v0.0.4 tag on GitHub
- document git-based dependency in llm crate AGENTS notes

## Testing
- `cargo test -p llm`

------
https://chatgpt.com/codex/tasks/task_e_68b785f40b68832aa7b75a01ccc815f0