### PR TITLE
feat(llm): capture invalid tool call arguments

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -43,6 +43,7 @@ Trait-based LLM client implementations for multiple providers.
 - Core message and tool types defined locally instead of re-exporting from `ollama-rs`
   - tool calls hold name and arguments directly
     - arguments store parsed JSON or the original string on parse failure
+    - serialization round-trips valid JSON or raw string arguments
   - tool info stores name, description, and parameters without wrapper enums
   - chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
     - tool calls include an `id` string, assigned locally when missing

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -42,6 +42,7 @@ Trait-based LLM client implementations for multiple providers.
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
 - Core message and tool types defined locally instead of re-exporting from `ollama-rs`
   - tool calls hold name and arguments directly
+    - arguments store parsed JSON or the original string on parse failure
   - tool info stores name, description, and parameters without wrapper enums
   - chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
     - tool calls include an `id` string, assigned locally when missing
@@ -60,6 +61,7 @@ Trait-based LLM client implementations for multiple providers.
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s
     - join handle resolves on completion with history updated in place
+  - malformed tool call arguments yield `"Tool Failed: bad JSON"` without invoking the executor
 - `mcp` module
 - `load_mcp_servers` starts configured MCP servers and collects tool schemas
   - tool names are prefixed with the server name

--- a/crates/llm/src/gpt_oss.rs
+++ b/crates/llm/src/gpt_oss.rs
@@ -116,7 +116,10 @@ fn build_prompt(
                     }
                 }
                 for tc in &a.tool_calls {
-                    let args = tc.arguments.to_string();
+                    let args = match &tc.arguments {
+                        Ok(v) => v.to_string(),
+                        Err(s) => s.clone(),
+                    };
                     convo_msgs.push(
                         Message::from_role_and_content(Role::Assistant, args)
                             .with_channel("commentary")
@@ -243,12 +246,14 @@ impl LlmClient for GptOssClient {
                                 if let Some(Content::Text(TextContent { text })) =
                                     msg.content.first()
                                 {
-                                    let args: Value =
-                                        serde_json::from_str(text).unwrap_or(Value::Null);
+                                    let arguments = match serde_json::from_str(text) {
+                                        Ok(v) => Ok(v),
+                                        Err(_) => Err(text.to_string()),
+                                    };
                                     out.push(Ok(ResponseChunk::ToolCall(ToolCall {
                                         id: Uuid::new_v4().to_string(),
                                         name: name.to_string(),
-                                        arguments: args,
+                                        arguments,
                                     })));
                                 }
                             }
@@ -369,7 +374,7 @@ mod tests {
                 tool_calls: vec![ToolCall {
                     id: "1".into(),
                     name: "add".into(),
-                    arguments: json!({"a": 2, "b": 2}),
+                    arguments: Ok(json!({"a": 2, "b": 2})),
                 }],
                 thinking: None,
             }),

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -287,6 +287,7 @@ pub trait LlmClient: Send + Sync {
 mod tests {
     use super::*;
     use schemars::{self, JsonSchema};
+    use serde_json::json;
 
     #[derive(JsonSchema)]
     struct Params {
@@ -302,5 +303,29 @@ mod tests {
             Value::String("int32".to_string())
         );
         assert!(value.get("$schema").is_none());
+    }
+
+    #[test]
+    fn tool_call_arguments_roundtrip_ok() {
+        let call = ToolCall {
+            id: "1".into(),
+            name: "test".into(),
+            arguments: Ok(json!({ "a": 1 })),
+        };
+        let serialized = serde_json::to_string(&call).unwrap();
+        let parsed: ToolCall = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed.arguments, Ok(json!({ "a": 1 })));
+    }
+
+    #[test]
+    fn tool_call_arguments_roundtrip_err() {
+        let call = ToolCall {
+            id: "1".into(),
+            name: "test".into(),
+            arguments: Err("not-json".into()),
+        };
+        let serialized = serde_json::to_string(&call).unwrap();
+        let parsed: ToolCall = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed.arguments, Err("not-json".into()));
     }
 }

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -55,11 +55,14 @@ impl LlmClient for OllamaClient {
                         msg.tool_calls = a
                             .tool_calls
                             .into_iter()
-                            .map(|tc| OllamaToolCall {
-                                function: OllamaToolCallFunction {
-                                    name: tc.name,
-                                    arguments: tc.arguments,
-                                },
+                            .map(|tc| {
+                                let arguments = tc.arguments.unwrap_or_else(|s| Value::String(s));
+                                OllamaToolCall {
+                                    function: OllamaToolCallFunction {
+                                        name: tc.name,
+                                        arguments,
+                                    },
+                                }
                             })
                             .collect();
                         msg.thinking = a.thinking;
@@ -116,7 +119,7 @@ impl LlmClient for OllamaClient {
                     .map(|tc| ToolCall {
                         id: Uuid::new_v4().to_string(),
                         name: tc.function.name,
-                        arguments: tc.function.arguments,
+                        arguments: Ok(tc.function.arguments),
                     })
                     .collect();
                 for tc in tool_calls {

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -81,13 +81,19 @@ impl LlmClient for OpenAiClient {
                         let tool_calls: Vec<ChatCompletionMessageToolCall> = a
                             .tool_calls
                             .into_iter()
-                            .map(|tc| ChatCompletionMessageToolCall {
-                                id: tc.id,
-                                r#type: ChatCompletionToolType::Function,
-                                function: FunctionCall {
-                                    name: tc.name,
-                                    arguments: tc.arguments.to_string(),
-                                },
+                            .map(|tc| {
+                                let arguments = match tc.arguments {
+                                    Ok(v) => v.to_string(),
+                                    Err(s) => s,
+                                };
+                                ChatCompletionMessageToolCall {
+                                    id: tc.id,
+                                    r#type: ChatCompletionToolType::Function,
+                                    function: FunctionCall {
+                                        name: tc.name,
+                                        arguments,
+                                    },
+                                }
                             })
                             .collect();
                         builder.tool_calls(tool_calls);
@@ -211,12 +217,14 @@ impl LlmClient for OpenAiClient {
                         if matches!(choice.finish_reason, Some(FinishReason::ToolCalls)) {
                             if !pending_tool_calls.is_empty() {
                                 for b in pending_tool_calls.drain(..) {
-                                    let args: Value =
-                                        serde_json::from_str(&b.arguments).unwrap_or(Value::Null);
+                                    let arguments = match serde_json::from_str(&b.arguments) {
+                                        Ok(v) => Ok(v),
+                                        Err(_) => Err(b.arguments.clone()),
+                                    };
                                     tool_calls.push(ToolCall {
                                         id: b.id.unwrap_or_else(|| Uuid::new_v4().to_string()),
                                         name: b.name.unwrap_or_default(),
-                                        arguments: args,
+                                        arguments,
                                     });
                                 }
                             }

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -76,7 +76,7 @@ mod tests {
             ResponseChunk::ToolCall(ToolCall {
                 id: "call-1".into(),
                 name: "test".into(),
-                arguments: Value::Null,
+                arguments: Ok(Value::Null),
             }),
             ResponseChunk::Done,
         ]);


### PR DESCRIPTION
## Summary
- retain original tool call arguments when JSON parsing fails
- report bad JSON without invoking tools
- render tool call arguments as raw strings when parsing fails

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b7bf62b1b0832a9a301c69b9757942