### PR TITLE
fix: preserve ToolCall id across tool events

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -61,6 +61,7 @@ Trait-based LLM client implementations for multiple providers.
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s
     - join handle resolves on completion with history updated in place
     - `ToolStarted` events include original argument strings when parsing fails
+    - `ToolStarted` and `ToolResult` keep the original `ToolCall` id
 - `mcp` module
 - `load_mcp_servers` starts configured MCP servers and collects tool schemas
   - tool names are prefixed with the server name

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -119,6 +119,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - final responses render markdown via termimad
       - streaming updates append thinking text, tool calls, and tool results
       - tool steps display original argument strings when JSON parsing fails
+      - tool steps keyed by the original `ToolCall` id
       - wrapped lines prefix continuation lines with `│`
       - tool step headers show tool name italic and underlined
         - failed tools display the name in red

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -211,7 +211,7 @@ impl App {
                 ResponseChunk::Done => {}
             },
             ToolEvent::ToolStarted {
-                id,
+                call_id,
                 name,
                 args,
                 args_invalid,
@@ -221,18 +221,20 @@ impl App {
                 let arg_str = args_invalid.unwrap_or_else(|| args.to_string());
                 self.conversation.add_tool_step(ToolStep::new(
                     name,
-                    id,
+                    call_id,
                     arg_str,
                     String::new(),
                     true,
                 ));
             }
-            ToolEvent::ToolResult { id, result, .. } => {
+            ToolEvent::ToolResult {
+                call_id, result, ..
+            } => {
                 let (text, failed) = match result {
                     Ok(t) => (t, false),
                     Err(e) => (format!("Tool Failed: {}", e), true),
                 };
-                self.conversation.update_tool_result(id, text, failed);
+                self.conversation.update_tool_result(&call_id, text, failed);
             }
         }
     }

--- a/crates/llment/src/conversation/tool_step.rs
+++ b/crates/llment/src/conversation/tool_step.rs
@@ -11,7 +11,7 @@ use super::node::ConvNode;
 
 pub struct ToolStep {
     pub(crate) name: String,
-    pub(crate) id: usize,
+    pub(crate) id: String,
     pub(crate) args: String,
     pub(crate) result: String,
     pub(crate) collapsed: bool,
@@ -24,7 +24,7 @@ pub struct ToolStep {
 }
 
 impl ToolStep {
-    pub fn new(name: String, id: usize, args: String, result: String, collapsed: bool) -> Self {
+    pub fn new(name: String, id: String, args: String, result: String, collapsed: bool) -> Self {
         Self {
             name,
             id,


### PR DESCRIPTION
## Summary
- keep original `ToolCall` id in `ToolEvent::ToolStarted` and `ToolResult`
- track tool steps in `llment` by `ToolCall` id to avoid rewriting

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b815ce077c832a8c4c269a954f4311