### PR TITLE
feat: track session request count

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -59,6 +59,7 @@ Trait-based LLM client implementations for multiple providers.
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s
+    - `RequestStarted` fires when a new request is sent
     - join handle resolves on completion with history updated in place
     - `ToolStarted` events include original argument strings when parsing fails
     - `ToolStarted` and `ToolResult` keep the original `ToolCall` id

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -66,7 +66,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - host defaults to provider-specific configuration when omitted
         - retains conversation history and token counters
       - `/quit` exits the application
-      - `/clear` resets conversation history, aborts any pending request, and zeroes session and context counters
+      - `/clear` resets conversation history, aborts any pending request, and zeroes context counters
       - `/redo` rolls back the last assistant block, restores the previous user message in the input, refocuses the prompt for editing, aborts any pending request, and recalculates context tokens
       - `/repair` removes assistant blocks with no content or tool calls
       - `/continue` resends the conversation without adding a new user message
@@ -100,7 +100,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
   - Esc exits the application
   - 1-line status area
     - shows state, provider, model, and active prompt and role when set on the left
-    - right-aligned: `ctx <context_tokens>t, Σ <session_in_tokens>t=> <session_out_tokens>t`
+    - right-aligned: `ctx <context_tokens>t, Σ <session_request_count>r <session_in_tokens>t=> <session_out_tokens>t`
   - conversation state tracking
     - states: idle, thinking, calling tool, responding
     - thinking chunks switch to thinking state


### PR DESCRIPTION
## Summary
- emit ToolEvent::RequestStarted for each llm request
- track and display session request count in llment without resetting on clear
- show request count alongside token totals as `Σ <requests>r <input>t=> <output>t`

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b81c803a18832a96e8ee57dcbe40c4