### PR TITLE
fix(llm): handle invalid tool arguments

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -63,6 +63,7 @@ Trait-based LLM client implementations for multiple providers.
     - join handle resolves on completion with history updated in place
     - `ToolStarted` events include original argument strings when parsing fails
     - `ToolStarted` and `ToolResult` keep the original `ToolCall` id
+  - tool calls with invalid arguments skip executor invocation and return "Could not parse arguments as JSON"
 - `mcp` module
 - `load_mcp_servers` starts configured MCP servers and collects tool schemas
   - tool names are prefixed with the server name


### PR DESCRIPTION
## Summary
- avoid executing tools when arguments fail to parse as JSON
- centralize invalid-argument error handling in spawned task
- test executor skip path for invalid tool arguments
- document invalid argument behaviour in llm crate

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68b8222801c0832aa0c32005da027587