### PR TITLE
refactor: rename GptOss provider to Harmony

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -26,10 +26,10 @@ Trait-based LLM client implementations for multiple providers.
 ## Features
 - LLM clients
   - `LlmClient` trait streams chat responses and lists supported model names
-- implementations for Ollama, OpenAI, GptOss, and Gemini
-- GptOss client uses v1/completions with Harmony format for `gpt-oss`
+- implementations for Ollama, OpenAI, Harmony, and Gemini
+- Harmony client uses v1/completions with Harmony format for `gpt-oss`
   - sends raw token arrays to the llama-server endpoint
-- GptOss client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
+- Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON
@@ -87,5 +87,5 @@ Trait-based LLM client implementations for multiple providers.
 
 ## Constraints
 - uses provider-specific default host when none is supplied
-- GptOss defaults to `http://localhost:8000/v1` and supports only `gpt-oss` via v1/completions
+- Harmony defaults to `http://localhost:8000/v1` and supports only `gpt-oss` via v1/completions
 - deprecated `function_call` streaming is no longer supported

--- a/crates/llm/src/harmony.rs
+++ b/crates/llm/src/harmony.rs
@@ -18,11 +18,11 @@ use openai_harmony::{
 use serde_json::Value;
 use uuid::Uuid;
 
-pub struct GptOssClient {
+pub struct HarmonyClient {
     inner: Client<OpenAIConfig>,
 }
 
-impl GptOssClient {
+impl HarmonyClient {
     pub fn new(host: Option<&str>) -> Self {
         let config = match host {
             Some(h) => OpenAIConfig::default().with_api_base(h),
@@ -181,7 +181,7 @@ fn build_prompt(
 }
 
 #[async_trait]
-impl LlmClient for GptOssClient {
+impl LlmClient for HarmonyClient {
     async fn send_chat_messages_stream(
         &self,
         request: ChatMessageRequest,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -128,7 +128,7 @@ impl ChatMessageRequest {
 }
 
 pub mod gemini;
-pub mod gpt_oss;
+pub mod harmony;
 pub mod mcp;
 pub mod ollama;
 pub mod openai;
@@ -142,7 +142,7 @@ pub enum Provider {
     #[default]
     Ollama,
     Openai,
-    GptOss,
+    Harmony,
     Gemini,
 }
 
@@ -189,7 +189,7 @@ pub fn client_from(
     let inner: Arc<dyn LlmClient> = match provider {
         Provider::Ollama => Arc::new(ollama::OllamaClient::new(host)?),
         Provider::Openai => Arc::new(openai::OpenAiClient::new(host)),
-        Provider::GptOss => Arc::new(gpt_oss::GptOssClient::new(host)),
+        Provider::Harmony => Arc::new(harmony::HarmonyClient::new(host)),
         Provider::Gemini => Arc::new(gemini::GeminiClient::new(host)),
     };
     Ok(Client {

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -32,7 +32,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 ## Features
 - CLI arguments
   - `--provider` selects LLM backend
-    - defaults to GptOss when omitted
+    - defaults to Harmony when omitted
   - `--model` sets the model identifier
   - `--host` optionally configures the LLM host URL; provider default used when omitted
   - `--mcp` loads MCP server configuration

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -64,7 +64,7 @@ impl Drop for TerminalGuard {
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[arg(long, value_enum, default_value_t = Provider::GptOss)]
+    #[arg(long, value_enum, default_value_t = Provider::Harmony)]
     provider: Provider,
     /// Model identifier to use
     #[arg(long, default_value = "gpt-oss:20b")]


### PR DESCRIPTION
## Summary
- rename GptOss client to Harmony
- update provider enum and CLI default
- refresh docs to reference Harmony

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b82c8b528c832a8e9d3ecc464a75d8