### PR TITLE
refactor(llm): rename Gemini provider and client to GeminiRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run with defaults (preferred):
 * `llama-server` (preferred)
 * `openai`
   * Status: incomplete for use with official OpenAI models, uses the `chat/` api which does not support thinking 
-* `gemini`
+* `gemini-rs`
   * Status: works but incomplete. Does not send encrypted thinking tokens back. Some API bugs in gemini-rs.
   * Requires GEMINI_API_KEY in env.
 * `ollama`

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -26,7 +26,7 @@ Trait-based LLM client implementations for multiple providers.
 ## Features
 - LLM clients
   - `LlmClient` trait streams chat responses and lists supported model names
-- implementations for Ollama, OpenAI, Harmony, and Gemini
+- implementations for Ollama, OpenAI, Harmony, and GeminiRs
 - Harmony client uses v1/completions with Harmony format for `gpt-oss`
   - sends raw token arrays to the llama-server endpoint
 - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -16,11 +16,11 @@ use super::{
     to_openapi_schema,
 };
 
-pub struct GeminiClient {
+pub struct GeminiRsClient {
     inner: Client,
 }
 
-impl GeminiClient {
+impl GeminiRsClient {
     pub fn new(_host: Option<&str>) -> Self {
         Self {
             inner: Client::instance(),
@@ -29,7 +29,7 @@ impl GeminiClient {
 }
 
 #[async_trait]
-impl LlmClient for GeminiClient {
+impl LlmClient for GeminiRsClient {
     async fn send_chat_messages_stream(
         &self,
         request: ChatMessageRequest,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -143,7 +143,7 @@ pub enum Provider {
     Ollama,
     Openai,
     Harmony,
-    Gemini,
+    GeminiRs,
 }
 
 #[derive(Clone)]
@@ -190,7 +190,7 @@ pub fn client_from(
         Provider::Ollama => Arc::new(ollama::OllamaClient::new(host)?),
         Provider::Openai => Arc::new(openai::OpenAiClient::new(host)),
         Provider::Harmony => Arc::new(harmony::HarmonyClient::new(host)),
-        Provider::Gemini => Arc::new(gemini::GeminiClient::new(host)),
+        Provider::GeminiRs => Arc::new(gemini::GeminiRsClient::new(host)),
     };
     Ok(Client {
         inner,


### PR DESCRIPTION
## Summary
- rename Gemini provider to GeminiRs
- rename GeminiClient to GeminiRsClient
- update documentation and AGENTS notes accordingly

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8316d096c832a91ded628b59f144e