### PR TITLE
refactor: rename openai provider to OpenaiChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Run with defaults (preferred):
       > llment --host http://localhost:11434 --provider ollama --model qwen3:latest
       ```
     </details>
-* `openai` - uses [async-openai](https://crates.io/crates/async-openai) to connect with models via v1/chat/completions API
+* `openai-chat` - uses [async-openai](https://crates.io/crates/async-openai) to connect with models via v1/chat/completions API
   * <details>
       <summary>Example - Ollama via OpenAI compat API</summary>
      
       ```sh
-      > llment --host http://localhost:11434 --provider openai --model qwen3:latest
+      > llment --host http://localhost:11434 --provider openai-chat --model qwen3:latest
       ```
     </details>
 * `gemini-rust` - uses the [gemini-rust](https://crates.io/crates/gemini-rust) crate to interface with the Gemini API

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -26,7 +26,7 @@ Trait-based LLM client implementations for multiple providers.
 ## Features
 - LLM clients
 - `LlmClient` trait streams chat responses and lists supported model names
-- implementations for Ollama, OpenAI, Harmony, and GeminiRust
+- implementations for Ollama, OpenaiChat, Harmony, and GeminiRust
   - GeminiRust function responses place success data under an `output` field
     - TODO: support the `error` field
 - Harmony client uses v1/completions with Harmony format for `gpt-oss`
@@ -55,8 +55,8 @@ Trait-based LLM client implementations for multiple providers.
   - usage chunks carry `input_tokens` and `output_tokens`
   - tool call chunks hold a single `ToolCall` and repeat as needed
   - thinking, tool calls, and content stream first, followed by optional usage then `Done`
-  - OpenAI client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
-  - OpenAI client parses `reasoning_content` from streamed responses into thinking text
+  - OpenaiChat client converts assistant history messages with tool calls into request `tool_calls` and stitches streaming tool call deltas into complete tool calls
+  - OpenaiChat client parses `reasoning_content` from streamed responses into thinking text
 - Tool orchestration
   - `tools` module exposes a `ToolExecutor` trait
   - `run_tool_loop` streams responses, executes tools, and issues follow-up requests

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -131,7 +131,7 @@ pub mod gemini_rust;
 pub mod harmony;
 pub mod mcp;
 pub mod ollama;
-pub mod openai;
+pub mod openai_chat;
 pub mod test_provider;
 pub mod tools;
 
@@ -141,7 +141,7 @@ pub use test_provider::TestProvider;
 pub enum Provider {
     #[default]
     Ollama,
-    Openai,
+    OpenaiChat,
     Harmony,
     GeminiRust,
 }
@@ -188,7 +188,7 @@ pub fn client_from(
 ) -> Result<Client, Box<dyn Error + Send + Sync>> {
     let inner: Arc<dyn LlmClient> = match provider {
         Provider::Ollama => Arc::new(ollama::OllamaClient::new(host)?),
-        Provider::Openai => Arc::new(openai::OpenAiClient::new(host)),
+        Provider::OpenaiChat => Arc::new(openai_chat::OpenaiChatClient::new(host)),
         Provider::Harmony => Arc::new(harmony::HarmonyClient::new(host)),
         Provider::GeminiRust => Arc::new(gemini_rust::GeminiRustClient::new(host)?),
     };

--- a/crates/llm/src/openai_chat.rs
+++ b/crates/llm/src/openai_chat.rs
@@ -38,11 +38,11 @@ struct StreamingDelta {
     tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
 }
 
-pub struct OpenAiClient {
+pub struct OpenaiChatClient {
     inner: Client<OpenAIConfig>,
 }
 
-impl OpenAiClient {
+impl OpenaiChatClient {
     pub fn new(host: Option<&str>) -> Self {
         let config = match host {
             Some(h) => OpenAIConfig::default().with_api_base(h),
@@ -55,7 +55,7 @@ impl OpenAiClient {
 }
 
 #[async_trait]
-impl LlmClient for OpenAiClient {
+impl LlmClient for OpenaiChatClient {
     async fn send_chat_messages_stream(
         &self,
         request: ChatMessageRequest,


### PR DESCRIPTION
## Summary
- rename OpenAI provider variant and client to `OpenaiChat`
- update docs and AGENTS references to `openai-chat`

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91b0df9cc832a92815ef953de7ccf