### PR TITLE
feat(llm): call llama-server completions for harmony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "ollama-rs",
  "openai-harmony",
  "reqwest",
+ "reqwest-eventsource",
  "rmcp 0.4.0",
  "schemars 1.0.4",
  "serde",

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Run with defaults (preferred):
 
 ## Providers
 `--provider` can be used to select a different provider:
-* `harmony` (preferred) uses [async-openai](https://crates.io/crates/async-openai) to connect with [openai/harmony](https://github.com/openai/harmony) compatible models via v1/completions API
-* `ollama` - uses the [ollama-rs](https://crates.io/crates/ollama-rs) crate to interface with the Ollama API
+* `harmony` (preferred) connects with [openai/harmony](https://github.com/openai/harmony) compatible models via the [llama-server](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) `/completion` API
+* `ollama` - uses [ollama-rs](https://crates.io/crates/ollama-rs) to interface with the Ollama API
   * <details>
       <summary>Example</summary>
      
@@ -29,7 +29,7 @@ Run with defaults (preferred):
       > llment --host http://localhost:11434 --provider ollama --model qwen3:latest
       ```
     </details>
-* `openai-chat` - uses [async-openai](https://crates.io/crates/async-openai) to connect with OpenAI's chat completions API
+* `openai-chat` - uses [async-openai](https://crates.io/crates/async-openai) to connect with OpenAI's `/v1/chat/completions` API
   * <details>
       <summary>Example - Ollama via OpenAI compat API</summary>
      

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -14,6 +14,10 @@ Trait-based LLM client implementations for multiple providers.
   - communicate with Ollama using streaming and tools
 - async-openai
   - connect to OpenAI models
+- reqwest
+  - direct llama-server HTTP calls
+- reqwest-eventsource
+  - handle server-sent events from llama-server
 - openai-harmony (v0.0.4, git tag)
   - render Harmony prompts and parse responses for gpt-oss
 - gemini-rust
@@ -29,8 +33,8 @@ Trait-based LLM client implementations for multiple providers.
   - implementations for Ollama, OpenAiChat, Harmony, and GeminiRust
   - GeminiRust function responses place success data under an `output` field
     - TODO: support the `error` field
-- Harmony client uses v1/completions with Harmony format for `gpt-oss`
-  - sends raw token arrays to the llama-server endpoint
+- Harmony client uses `/completions` with Harmony format for `gpt-oss`
+  - sends raw token arrays via `llama_server_completions`
 - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
@@ -89,5 +93,5 @@ Trait-based LLM client implementations for multiple providers.
 
 ## Constraints
 - uses provider-specific default host when none is supplied
-- Harmony defaults to `http://localhost:8000/v1` and supports only `gpt-oss` via v1/completions
+- Harmony defaults to `http://localhost:8000` and supports only `gpt-oss` via `/completions`
 - deprecated `function_call` streaming is no longer supported

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -33,8 +33,8 @@ Trait-based LLM client implementations for multiple providers.
   - implementations for Ollama, OpenAiChat, Harmony, and GeminiRust
   - GeminiRust function responses place success data under an `output` field
     - TODO: support the `error` field
-- Harmony client uses `/completions` with Harmony format for `gpt-oss`
-  - sends raw token arrays via `llama_server_completions`
+- Harmony client uses `/completion` with Harmony format for `gpt-oss`
+  - sends raw token arrays via `llama_server_completion`
 - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
@@ -93,5 +93,5 @@ Trait-based LLM client implementations for multiple providers.
 
 ## Constraints
 - uses provider-specific default host when none is supplied
-- Harmony defaults to `http://localhost:8000` and supports only `gpt-oss` via `/completions`
+- Harmony defaults to `http://localhost:8000` and supports only `gpt-oss` via `/completion`
 - deprecated `function_call` streaming is no longer supported

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -14,6 +14,7 @@ gemini-rust = "1.3.1"
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
 openai-harmony = { git = "https://github.com/openai/harmony", tag = "v0.0.4", version = "0.0.4" }
 reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
+reqwest-eventsource = "0.6"
 rmcp = { version = "0.4.0", features = ["client", "transport-child-process"] }
 schemars = "1.0.4"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/llm/src/harmony.rs
+++ b/crates/llm/src/harmony.rs
@@ -214,11 +214,8 @@ impl LlmClient for HarmonyClient {
             Ok(chunk) => {
                 output_tokens += chunk.tokens.len() as u32;
                 let mut out = vec![];
-                if !chunk.content.is_empty() {
-                    let tokens = encoding
-                        .tokenizer()
-                        .encode_with_special_tokens(&chunk.content);
-                    for t in tokens {
+                if !chunk.tokens.is_empty() {
+                    for t in chunk.tokens {
                         parser.process(t).ok();
                         if let Some(delta) = parser.last_content_delta().ok().flatten() {
                             if !delta.is_empty() && parser.current_recipient().is_none() {

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -129,6 +129,7 @@ impl ChatMessageRequest {
 
 pub mod gemini_rust;
 pub mod harmony;
+mod llama_server;
 pub mod mcp;
 pub mod ollama;
 pub mod openai_chat;

--- a/crates/llm/src/llama_server.rs
+++ b/crates/llm/src/llama_server.rs
@@ -15,18 +15,13 @@ pub struct CompletionRequest {
 #[derive(Default, Deserialize)]
 pub struct CompletionResponse {
     #[serde(default)]
-    pub content: String,
-    #[serde(default)]
     pub tokens: Vec<u32>,
     #[serde(default)]
     pub stop: bool,
 }
 
-pub type CompletionStream = Pin<
-    Box<
-        dyn Stream<Item = Result<CompletionResponse, Box<dyn Error + Send + Sync>>> + Send,
-    >,
->;
+pub type CompletionStream =
+    Pin<Box<dyn Stream<Item = Result<CompletionResponse, Box<dyn Error + Send + Sync>>> + Send>>;
 
 /// Create a [`CompletionStream`] for the llama-server `/completion` endpoint.
 pub async fn llama_server_completion(
@@ -37,21 +32,19 @@ pub async fn llama_server_completion(
     let url = format!("{}/completion", host.trim_end_matches('/'));
     let req = client.post(url).json(&request);
     let es = EventSource::new(req)?;
-    let stream = es.filter_map(|event| {
-        match event {
-            Ok(Event::Message(msg)) => {
-                if msg.data == "[DONE]" {
-                    None
-                } else {
-                    Some(
-                        serde_json::from_str::<CompletionResponse>(&msg.data)
-                            .map_err(|e| Box::<dyn Error + Send + Sync>::from(e)),
-                    )
-                }
+    let stream = es.filter_map(|event| match event {
+        Ok(Event::Message(msg)) => {
+            if msg.data == "[DONE]" {
+                None
+            } else {
+                Some(
+                    serde_json::from_str::<CompletionResponse>(&msg.data)
+                        .map_err(|e| Box::<dyn Error + Send + Sync>::from(e)),
+                )
             }
-            Ok(Event::Open) => None,
-            Err(e) => Some(Err(Box::<dyn Error + Send + Sync>::from(e))),
         }
+        Ok(Event::Open) => None,
+        Err(e) => Some(Err(Box::<dyn Error + Send + Sync>::from(e))),
     });
     Ok(Box::pin(stream))
 }

--- a/crates/llm/src/llama_server.rs
+++ b/crates/llm/src/llama_server.rs
@@ -1,14 +1,57 @@
-use std::error::Error;
+use std::{error::Error, pin::Pin};
 
-use reqwest_eventsource::EventSource;
+use reqwest_eventsource::{Event, EventSource};
+use serde::{Deserialize, Serialize};
+use tokio_stream::{Stream, StreamExt};
 
-/// Create an [`EventSource`] for the llama-server `/completions` endpoint.
-pub async fn llama_server_completions(
+/// Request payload for the llama-server `/completion` endpoint.
+#[derive(Serialize)]
+pub struct CompletionRequest {
+    pub prompt: Vec<u32>,
+    pub stream: bool,
+}
+
+/// Streamed response chunk from the llama-server `/completion` endpoint.
+#[derive(Default, Deserialize)]
+pub struct CompletionResponse {
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub tokens: Vec<u32>,
+    #[serde(default)]
+    pub stop: bool,
+}
+
+pub type CompletionStream = Pin<
+    Box<
+        dyn Stream<Item = Result<CompletionResponse, Box<dyn Error + Send + Sync>>> + Send,
+    >,
+>;
+
+/// Create a [`CompletionStream`] for the llama-server `/completion` endpoint.
+pub async fn llama_server_completion(
     client: &reqwest::Client,
     host: &str,
-    request: async_openai::types::CreateCompletionRequest,
-) -> Result<EventSource, Box<dyn Error + Send + Sync>> {
-    let url = format!("{}/completions", host.trim_end_matches('/'));
+    request: CompletionRequest,
+) -> Result<CompletionStream, Box<dyn Error + Send + Sync>> {
+    let url = format!("{}/completion", host.trim_end_matches('/'));
     let req = client.post(url).json(&request);
-    Ok(EventSource::new(req)?)
+    let es = EventSource::new(req)?;
+    let stream = es.filter_map(|event| {
+        match event {
+            Ok(Event::Message(msg)) => {
+                if msg.data == "[DONE]" {
+                    None
+                } else {
+                    Some(
+                        serde_json::from_str::<CompletionResponse>(&msg.data)
+                            .map_err(|e| Box::<dyn Error + Send + Sync>::from(e)),
+                    )
+                }
+            }
+            Ok(Event::Open) => None,
+            Err(e) => Some(Err(Box::<dyn Error + Send + Sync>::from(e))),
+        }
+    });
+    Ok(Box::pin(stream))
 }

--- a/crates/llm/src/llama_server.rs
+++ b/crates/llm/src/llama_server.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+
+use reqwest_eventsource::EventSource;
+
+/// Create an [`EventSource`] for the llama-server `/completions` endpoint.
+pub async fn llama_server_completions(
+    client: &reqwest::Client,
+    host: &str,
+    request: async_openai::types::CreateCompletionRequest,
+) -> Result<EventSource, Box<dyn Error + Send + Sync>> {
+    let url = format!("{}/completions", host.trim_end_matches('/'));
+    let req = client.post(url).json(&request);
+    Ok(EventSource::new(req)?)
+}


### PR DESCRIPTION
## Summary
- switch Harmony client to llama-server `/completions`
- add `llama_server_completions` helper using `reqwest-eventsource`

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68ba4330d124832aa4705e1c86788191