### PR TITLE
feat(llm): send tool-specific GBNF grammar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ The project is divided into crates:
 * [crates/llm](crates/llm/AGENTS.md)
 * [crates/llment](crates/llment/AGENTS.md)
 * [crates/mcp-shell](crates/mcp-shell/AGENTS.md)
+* [crates/gbnf-rs](crates/gbnf-rs/AGENTS.md)
 
 # Glossary
 MCP: Model Context Protocol

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gbnf-rs"
+version = "0.1.0"
+dependencies = [
+ "insta",
+ "schemars 1.0.4",
+ "serde_json",
+]
+
+[[package]]
 name = "gemini-rust"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,9 +1727,9 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "once_cell",
@@ -1927,6 +1936,7 @@ dependencies = [
  "async-trait",
  "clap",
  "futures-util",
+ "gbnf-rs",
  "gemini-rust",
  "ollama-rs",
  "openai-harmony",

--- a/crates/gbnf-rs/AGENTS.md
+++ b/crates/gbnf-rs/AGENTS.md
@@ -1,0 +1,24 @@
+# gbnf-rs
+Generate GBNF grammar ASTs from `schemars::Schema` inputs.
+
+## Dependencies
+- schemars
+  - parse and inspect JSON Schemas
+- insta
+  - snapshot testing of generated grammars
+
+## Features
+- Builds an AST of rules that can be rendered to GBNF
+- Supports referencing external non-terminal symbols like `ws`, `string`, and `number`
+- Ensures internal rule names are unique across generations
+- Top-level rule names are sanitized to letters, digits, and `-`, prefixed with `r` when needed, and suffixed with a unique counter
+- Avoids emitting redundant rules for simple property types by inlining their expressions
+- Understands schema `type` arrays, ignoring `null` when present
+- Handles array schemas by expanding item expressions into comma-separated sequences
+- Snapshot tests cover schemas with required and optional fields, including nested structs and arrays of structs
+- Resolves `$ref` definitions, reusing generated rules for shared schemas
+
+## Constraints
+- Generated object rules include all properties
+  - required properties appear first
+  - optional properties may follow in any order

--- a/crates/gbnf-rs/Cargo.toml
+++ b/crates/gbnf-rs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gbnf-rs"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+schemars = "1.0.4"
+serde_json = "1.0.143"
+
+[dev-dependencies]
+insta = "1.43.2"

--- a/crates/gbnf-rs/src/lib.rs
+++ b/crates/gbnf-rs/src/lib.rs
@@ -1,0 +1,395 @@
+use schemars::Schema;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::{self, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Debug)]
+pub enum Expr {
+    Literal(String),
+    Ref(String),
+    Seq(Vec<Expr>),
+    Choice(Vec<Expr>),
+    Repeat(Box<Expr>),
+    Optional(Box<Expr>),
+}
+
+#[derive(Clone, Debug)]
+pub struct Rule {
+    pub name: String,
+    pub expr: Expr,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Grammar {
+    pub rules: Vec<Rule>,
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Expr::Literal(s) => {
+                f.write_char('"')?;
+                for ch in s.chars() {
+                    if ch == '"' || ch == '\\' {
+                        f.write_char('\\')?;
+                    }
+                    f.write_char(ch)?;
+                }
+                f.write_char('"')
+            }
+            Expr::Ref(s) => f.write_str(s),
+            Expr::Seq(v) => {
+                for (i, e) in v.iter().enumerate() {
+                    if i > 0 {
+                        f.write_char(' ')?;
+                    }
+                    write!(f, "{}", e)?;
+                }
+                Ok(())
+            }
+            Expr::Choice(v) => {
+                for (i, e) in v.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(" | ")?;
+                    }
+                    write!(f, "{}", e)?;
+                }
+                Ok(())
+            }
+            Expr::Repeat(e) => write!(f, "({})*", e),
+            Expr::Optional(e) => write!(f, "({})?", e),
+        }
+    }
+}
+
+impl fmt::Display for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ::= {}", self.name, self.expr)
+    }
+}
+
+impl fmt::Display for Grammar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, rule) in self.rules.iter().enumerate() {
+            if i > 0 {
+                f.write_char('\n')?;
+            }
+            write!(f, "{}", rule)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct Generator {
+    counter: AtomicUsize,
+}
+
+impl Generator {
+    pub fn new() -> Self {
+        Self {
+            counter: AtomicUsize::new(0),
+        }
+    }
+
+    fn unique(&self) -> String {
+        format!("r{}", self.counter.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn sanitize(&self, name: &str) -> String {
+        let mut out = String::new();
+        for ch in name.chars() {
+            if ch.is_ascii_alphanumeric() || ch == '-' {
+                out.push(ch);
+            } else {
+                out.push('-');
+            }
+        }
+        if out.is_empty() || !out.chars().next().unwrap().is_ascii_alphabetic() {
+            out.insert(0, 'r');
+        }
+        out
+    }
+
+    pub fn generate(&self, name: &str, schema: &Schema) -> Grammar {
+        let mut grammar = Grammar::default();
+        let defs: BTreeMap<String, Schema> = schema
+            .as_object()
+            .and_then(|o| o.get("$defs").or_else(|| o.get("definitions")))
+            .and_then(Value::as_object)
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| v.clone().try_into().ok().map(|s| (k.clone(), s)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut cache = HashMap::new();
+        let rule_name = format!("{}-{}", self.sanitize(name), self.unique());
+        let expr = self.expr_from_schema(schema, &defs, &mut cache, &mut grammar);
+        grammar.rules.insert(
+            0,
+            Rule {
+                name: rule_name,
+                expr,
+            },
+        );
+        grammar
+    }
+
+    fn maybe_rule(&self, expr: Expr, grammar: &mut Grammar) -> Expr {
+        match expr {
+            Expr::Ref(_) | Expr::Literal(_) => expr,
+            other => {
+                let name = self.unique();
+                grammar.rules.push(Rule {
+                    name: name.clone(),
+                    expr: other,
+                });
+                Expr::Ref(name)
+            }
+        }
+    }
+
+    fn expr_from_schema(
+        &self,
+        schema: &Schema,
+        defs: &BTreeMap<String, Schema>,
+        cache: &mut HashMap<String, String>,
+        grammar: &mut Grammar,
+    ) -> Expr {
+        if let Some(obj) = schema.as_object() {
+            if let Some(reference) = obj.get("$ref").and_then(Value::as_str) {
+                if let Some(name) = reference
+                    .strip_prefix("#/$defs/")
+                    .or_else(|| reference.strip_prefix("#/definitions/"))
+                {
+                    if let Some(existing) = cache.get(name) {
+                        return Expr::Ref(existing.clone());
+                    }
+                    if let Some(resolved) = defs.get(name) {
+                        let expr = self.expr_from_schema(resolved, defs, cache, grammar);
+                        let expr = self.maybe_rule(expr, grammar);
+                        if let Expr::Ref(rule) = &expr {
+                            cache.insert(name.to_string(), rule.clone());
+                        }
+                        return expr;
+                    }
+                }
+            }
+        }
+
+        let ty = schema
+            .as_object()
+            .and_then(|o| o.get("type"))
+            .and_then(|t| match t {
+                Value::String(s) => Some(s.clone()),
+                Value::Array(arr) => arr
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .find(|s| *s != "null")
+                    .map(|s| s.to_string()),
+                _ => None,
+            });
+
+        match ty.as_deref() {
+            Some("string") => Expr::Ref("string".into()),
+            Some("number") | Some("integer") => Expr::Ref("number".into()),
+            Some("boolean") => Expr::Choice(vec![
+                Expr::Literal("true".into()),
+                Expr::Literal("false".into()),
+            ]),
+            Some("object") => self.object_expr(schema, defs, cache, grammar),
+            Some("array") => self.array_expr(schema, defs, cache, grammar),
+            _ => Expr::Ref("json".into()),
+        }
+    }
+
+    fn object_expr(
+        &self,
+        schema: &Schema,
+        defs: &BTreeMap<String, Schema>,
+        cache: &mut HashMap<String, String>,
+        grammar: &mut Grammar,
+    ) -> Expr {
+        let obj = match schema.as_object() {
+            Some(o) => o,
+            None => return Expr::Ref("json".into()),
+        };
+        let props = obj.get("properties").and_then(Value::as_object);
+        let required: Vec<String> = obj
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(Value::as_str)
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut seq = Vec::new();
+        seq.push(Expr::Literal("{".into()));
+        seq.push(Expr::Ref("ws".into()));
+        let mut first = true;
+        if let Some(map) = props {
+            let mut required_props: Vec<_> = map
+                .iter()
+                .filter(|(name, _)| required.contains(*name))
+                .collect();
+            required_props.sort_by(|a, b| a.0.cmp(b.0));
+            for (name, subschema) in required_props {
+                if !first {
+                    seq.push(Expr::Literal(",".into()));
+                    seq.push(Expr::Ref("ws".into()));
+                }
+                first = false;
+                seq.push(Expr::Literal(format!("\"{}\"", name)));
+                seq.push(Expr::Ref("ws".into()));
+                seq.push(Expr::Literal(":".into()));
+                seq.push(Expr::Ref("ws".into()));
+                let subschema: Schema = subschema.clone().try_into().unwrap_or_default();
+                let expr = self.expr_from_schema(&subschema, defs, cache, grammar);
+                seq.push(self.maybe_rule(expr, grammar));
+            }
+
+            let mut optional_props: Vec<_> = map
+                .iter()
+                .filter(|(name, _)| !required.contains(*name))
+                .collect();
+            optional_props.sort_by(|a, b| a.0.cmp(b.0));
+
+            if !optional_props.is_empty() {
+                let mut choices = Vec::new();
+                for (name, subschema) in optional_props {
+                    let subschema: Schema = subschema.clone().try_into().unwrap_or_default();
+                    let expr = self.expr_from_schema(&subschema, defs, cache, grammar);
+                    let expr = self.maybe_rule(expr, grammar);
+                    choices.push(Expr::Seq(vec![
+                        Expr::Literal(format!("\"{}\"", name)),
+                        Expr::Ref("ws".into()),
+                        Expr::Literal(":".into()),
+                        Expr::Ref("ws".into()),
+                        expr,
+                    ]));
+                }
+
+                if first {
+                    seq.push(Expr::Optional(Box::new(Expr::Seq(vec![
+                        Expr::Choice(choices.clone()),
+                        Expr::Repeat(Box::new(Expr::Seq(vec![
+                            Expr::Literal(",".into()),
+                            Expr::Ref("ws".into()),
+                            Expr::Choice(choices),
+                        ]))),
+                    ]))));
+                } else {
+                    seq.push(Expr::Repeat(Box::new(Expr::Seq(vec![
+                        Expr::Literal(",".into()),
+                        Expr::Ref("ws".into()),
+                        Expr::Choice(choices),
+                    ]))));
+                }
+            }
+        }
+        seq.push(Expr::Ref("ws".into()));
+        seq.push(Expr::Literal("}".into()));
+        Expr::Seq(seq)
+    }
+
+    fn array_expr(
+        &self,
+        schema: &Schema,
+        defs: &BTreeMap<String, Schema>,
+        cache: &mut HashMap<String, String>,
+        grammar: &mut Grammar,
+    ) -> Expr {
+        let items_schema = schema.as_object().and_then(|o| o.get("items")).cloned();
+        let items_schema: Schema = match items_schema {
+            Some(s) => s.try_into().unwrap_or_default(),
+            None => return Expr::Ref("json".into()),
+        };
+        let item_expr = self.expr_from_schema(&items_schema, defs, cache, grammar);
+        let item_expr = self.maybe_rule(item_expr, grammar);
+        Expr::Seq(vec![
+            Expr::Literal("[".into()),
+            Expr::Ref("ws".into()),
+            Expr::Optional(Box::new(Expr::Seq(vec![
+                item_expr.clone(),
+                Expr::Repeat(Box::new(Expr::Seq(vec![
+                    Expr::Literal(",".into()),
+                    Expr::Ref("ws".into()),
+                    item_expr,
+                ]))),
+            ]))),
+            Expr::Ref("ws".into()),
+            Expr::Literal("]".into()),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schemars::JsonSchema;
+
+    #[derive(JsonSchema)]
+    struct ReplaceParams {
+        file_path: String,
+        new_string: String,
+        old_string: String,
+        expected_replacements: Option<usize>,
+    }
+
+    #[test]
+    fn replace_params_grammar() {
+        let schema = schemars::schema_for!(ReplaceParams);
+        let generator = Generator::new();
+        let grammar = generator.generate("params", &schema);
+        insta::assert_snapshot!(grammar.to_string(), @r###"
+params-r0 ::= "{" ws "\"file_path\"" ws ":" ws string "," ws "\"new_string\"" ws ":" ws string "," ws "\"old_string\"" ws ":" ws string ("," ws "\"expected_replacements\"" ws ":" ws number)* ws "}"
+"###);
+    }
+
+    #[derive(JsonSchema)]
+    struct ListDirectoryParams {
+        path: String,
+        ignore: Option<Vec<String>>,
+        include: Option<Vec<String>>,
+        include_hidden: Option<bool>,
+    }
+
+    #[test]
+    fn list_directory_params_grammar() {
+        let schema = schemars::schema_for!(ListDirectoryParams);
+        let generator = Generator::new();
+        let grammar = generator.generate("params", &schema);
+        insta::assert_snapshot!(grammar.to_string(), @r###"
+params-r0 ::= "{" ws "\"path\"" ws ":" ws string ("," ws "\"ignore\"" ws ":" ws r1 | "\"include\"" ws ":" ws r2 | "\"include_hidden\"" ws ":" ws r3)* ws "}"
+r1 ::= "[" ws (string ("," ws string)*)? ws "]"
+r2 ::= "[" ws (string ("," ws string)*)? ws "]"
+r3 ::= "true" | "false"
+"###);
+    }
+
+    #[derive(JsonSchema)]
+    struct Item {
+        value: String,
+    }
+
+    #[derive(JsonSchema)]
+    struct Container {
+        item: Item,
+        items: Vec<Item>,
+    }
+
+    #[test]
+    fn nested_structs_grammar() {
+        let schema = schemars::schema_for!(Container);
+        let generator = Generator::new();
+        let grammar = generator.generate("params", &schema);
+        insta::assert_snapshot!(grammar.to_string(), @r###"
+params-r0 ::= "{" ws "\"item\"" ws ":" ws r1 "," ws "\"items\"" ws ":" ws r2 ws "}"
+r1 ::= "{" ws "\"value\"" ws ":" ws string ws "}"
+r2 ::= "[" ws (r1 ("," ws r1)*)? ws "]"
+"###);
+    }
+}

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -26,6 +26,8 @@ Trait-based LLM client implementations for multiple providers.
   - connect to MCP servers
 - schemars
   - define and manipulate tool schemas
+- gbnf-rs
+  - generate GBNF grammars from tool schemas
 
 ## Features
 - LLM clients
@@ -35,7 +37,10 @@ Trait-based LLM client implementations for multiple providers.
     - TODO: support the `error` field
 - Harmony client uses `/completion` with Harmony format for `gpt-oss`
   - sends raw token arrays via `llama_server_completion`
-- Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
+  - sends a GBNF grammar that constrains tool call JSON to each tool's schema
+  - grammar base loaded from `.gbnf` file with `include_str!`
+  - tool-call rule appended to allow only declared tool names
+  - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -10,6 +10,7 @@ async-openai = { version = "0.29.0", features = ["byot"] }
 async-trait = "0.1.88"
 clap = { version = "4.5.43", features = ["derive"] }
 futures-util = "0.3.31"
+gbnf-rs = { version = "0.1.0", path = "../gbnf-rs" }
 gemini-rust = "1.3.1"
 ollama-rs = { git = "https://github.com/dstoc/ollama-rs", branch = "RobJellinghaus/streaming-tools", version = "0.3.2", features = ["macros", "stream"] }
 openai-harmony = { git = "https://github.com/openai/harmony", tag = "v0.0.4", version = "0.0.4" }

--- a/crates/llm/src/harmony.gbnf
+++ b/crates/llm/src/harmony.gbnf
@@ -1,0 +1,52 @@
+root         ::= harmony
+
+thinking  ::= "<|channel|>analysis<|message|>" not-end* "<|end|><|start|>assistant"
+preamble  ::= "<|channel|>commentary<|message|>" not-end* "<|end|><|start|>assistant"
+content   ::= "<|channel|>final<|message|>" not-return*
+harmony   ::= thinking (content | tool-call)
+
+tool-name ::= [A-Za-z0-9_.]+
+
+not-end ::= 
+    [^<] |
+    "<" [^|] |
+    "<|" [^e] |
+    "<|e" [^n] |
+    "<|en" [^d] |
+    "<|end" [^|] |
+    "<|end|" [^>]
+
+not-return ::= 
+    [^<] |
+    "<" [^|] |
+    "<|" [^r] |
+    "<|r" [^e] |
+    "<|re" [^t] |
+    "<|ret" [^u] |
+    "<|retu" [^r] |
+    "<|retur" [^n] |
+    "<|return" [^|] |
+    "<|return|" [^>]
+
+# From llama.cpp:grammars/json.gbnf
+json   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+object ::= "{" ws (
+            string ":" ws value
+    ("," ws string ":" ws value)*
+  )? "}" ws
+
+array  ::= "[" ws (
+            value
+    ("," ws value)*
+  )? "]" ws
+
+string ::= "\"" (
+    [^"\\\\\x7F\x00-\x1F] |
+    "\\" (["\\bfnrt] | "u" [0-9a-fA-F]{4}) # escapes
+  )* "\"" ws
+
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9] [1-9]{0,15})? ws
+
+# Optional space: by convention, applied in this grammar after literal chars when allowed
+ws ::= | " " | "\n" [ \t]{0,20}

--- a/crates/llm/src/harmony.gbnf
+++ b/crates/llm/src/harmony.gbnf
@@ -3,9 +3,7 @@ root         ::= harmony
 thinking  ::= "<|channel|>analysis<|message|>" not-end* "<|end|><|start|>assistant"
 preamble  ::= "<|channel|>commentary<|message|>" not-end* "<|end|><|start|>assistant"
 content   ::= "<|channel|>final<|message|>" not-return*
-harmony   ::= thinking (content | tool-call)
-
-tool-name ::= [A-Za-z0-9_.]+
+harmony   ::= thinking (content | preamble? tool-call)
 
 not-end ::= 
     [^<] |
@@ -46,7 +44,7 @@ string ::= "\"" (
     "\\" (["\\bfnrt] | "u" [0-9a-fA-F]{4}) # escapes
   )* "\"" ws
 
-number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9] [1-9]{0,15})? ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9]{0,16})? ws
 
 # Optional space: by convention, applied in this grammar after literal chars when allowed
 ws ::= | " " | "\n" [ \t]{0,20}

--- a/crates/llm/src/harmony.rs
+++ b/crates/llm/src/harmony.rs
@@ -209,7 +209,7 @@ fn build_grammar(tools: &[ToolInfo]) -> Result<String, Box<dyn Error + Send + Sy
     }
 
     let tool_call_rule = format!(
-        "tool-call ::= preamble? \"<|channel|>commentary to=functions.\" ({})",
+        "tool-call ::= \"<|channel|>commentary to=functions.\" ({})",
         tool_alts.join(" | ")
     );
     grammar.push('\n');

--- a/crates/llm/src/llama_server.rs
+++ b/crates/llm/src/llama_server.rs
@@ -9,6 +9,8 @@ use tokio_stream::{Stream, StreamExt};
 pub struct CompletionRequest {
     pub prompt: Vec<u32>,
     pub stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grammar: Option<String>,
 }
 
 /// Streamed response chunk from the llama-server `/completion` endpoint.


### PR DESCRIPTION
## Summary
- generate per-tool GBNF grammar using gbnf and send to llama-server
- allow CompletionRequest to include an optional grammar string

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68ba6071d974832abd625bdde4147f17