### PR TITLE
chore(mcp-edit): test list_directory with mount path

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -25,6 +25,7 @@ MCP server offering file system editing utilities.
 - mount point hides actual workspace path in responses
   - defaults to `/home/user/workspace`
   - error messages include mount point paths for missing or invalid files
+  - accepts mount-point paths with or without a trailing slash
 - tools
   - `replace`
     - enforces the expected number of string replacements


### PR DESCRIPTION
## Summary
- handle absolute mount-point paths in `resolve`
- test `list_directory` using `/home/user/workspace` with and without trailing slash
- document mount-point path handling in `AGENTS.md`

## Testing
- `cargo fmt --all`
- `cargo test -p mcp-edit`


------
https://chatgpt.com/codex/tasks/task_e_68bbab82b8c8832aa0237b15a8d9d80d