### PR TITLE
fix: eliminate build warnings

### DIFF
--- a/crates/gbnf-rs/src/lib.rs
+++ b/crates/gbnf-rs/src/lib.rs
@@ -328,6 +328,7 @@ impl Generator {
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
     use super::*;
     use schemars::JsonSchema;
 

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -262,6 +262,7 @@ pub trait LlmClient: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
     use super::*;
     use schemars::{self, JsonSchema};
 

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::io::{stderr, stdout};
+use std::io::stdout;
 use std::time::Duration;
 
 use app::{App, AppModel};


### PR DESCRIPTION
## Summary
- remove unused stderr import in llment
- allow dead code in test modules to silence warnings in llm and gbnf-rs

## Testing
- `cargo build --all-targets --workspace`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68bbbd9fe1a4832ab81c7877eb40fb77