### PR TITLE
fix(llm): select correct grammar for harmony prefills

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -38,7 +38,8 @@ Trait-based LLM client implementations for multiple providers.
 - Harmony client uses `/completion` with Harmony format for `gpt-oss`
   - sends raw token arrays via `llama_server_completion`
   - sends a GBNF grammar that constrains tool call JSON to each tool's schema
-  - grammar base loaded from `.gbnf` file with `include_str!`
+  - grammar base loaded from `.gbnf` file with `include_str!` and no root rule
+    - appends `root ::= harmony` or `root ::= harmony_prefill_*` based on prefill context
   - tool-call rule appended to allow only declared tool names
   - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled

--- a/crates/llm/src/harmony.gbnf
+++ b/crates/llm/src/harmony.gbnf
@@ -1,9 +1,10 @@
-root         ::= harmony
-
 thinking  ::= "<|channel|>analysis<|message|>" not-end* "<|end|><|start|>assistant"
 preamble  ::= "<|channel|>commentary<|message|>" not-end* "<|end|><|start|>assistant"
 content   ::= "<|channel|>final<|message|>" not-return*
 harmony   ::= thinking (content | preamble? tool-call)
+
+harmony_prefill_thinking ::= not-end* "<|end|><|start|>assistant" (content | preamble? tool-call)
+harmony_prefill_content  ::= not-return*
 
 not-end ::= 
     [^<] |

--- a/crates/llm/src/harmony.gbnf
+++ b/crates/llm/src/harmony.gbnf
@@ -1,10 +1,10 @@
 thinking  ::= "<|channel|>analysis<|message|>" not-end* "<|end|><|start|>assistant"
 preamble  ::= "<|channel|>commentary<|message|>" not-end* "<|end|><|start|>assistant"
 content   ::= "<|channel|>final<|message|>" not-return*
-harmony   ::= thinking (content | preamble? tool-call)
 
-harmony_prefill_thinking ::= not-end* "<|end|><|start|>assistant" (content | preamble? tool-call)
-harmony_prefill_content  ::= not-return*
+harmony-default          ::= thinking (content | preamble? tool-call)
+harmony-prefill-thinking ::= not-end* "<|end|><|start|>assistant" (content | preamble? tool-call)
+harmony-prefill-content  ::= not-return*
 
 not-end ::= 
     [^<] |

--- a/crates/llm/src/harmony.rs
+++ b/crates/llm/src/harmony.rs
@@ -231,13 +231,13 @@ fn build_grammar(
 
     match root {
         GrammarRoot::Harmony => {
-            grammar.push_str("\nroot ::= harmony");
+            grammar.push_str("\nroot ::= harmony-default");
         }
         GrammarRoot::PrefillThinking => {
-            grammar.push_str("\nroot ::= harmony_prefill_thinking");
+            grammar.push_str("\nroot ::= harmony-prefill-thinking");
         }
         GrammarRoot::PrefillContent => {
-            grammar.push_str("\nroot ::= harmony_prefill_content");
+            grammar.push_str("\nroot ::= harmony-prefill-content");
         }
     }
     Ok(grammar)
@@ -476,12 +476,12 @@ mod tests {
     fn grammar_root_selection() {
         let g = build_grammar(&[], GrammarRoot::Harmony).unwrap();
         assert_eq!(g.matches("root ::=").count(), 1);
-        assert!(g.contains("root ::= harmony"));
+        assert!(g.contains("root ::= harmony-default"));
         let g = build_grammar(&[], GrammarRoot::PrefillThinking).unwrap();
         assert_eq!(g.matches("root ::=").count(), 1);
-        assert!(g.contains("root ::= harmony_prefill_thinking"));
+        assert!(g.contains("root ::= harmony-prefill-thinking"));
         let g = build_grammar(&[], GrammarRoot::PrefillContent).unwrap();
         assert_eq!(g.matches("root ::=").count(), 1);
-        assert!(g.contains("root ::= harmony_prefill_content"));
+        assert!(g.contains("root ::= harmony-prefill-content"));
     }
 }


### PR DESCRIPTION
## Summary
- add separate Harmony grammar productions for prefill scenarios
- choose grammar root based on prefill when building requests
- document grammar root selection in llm AGENTS guidelines
- remove default root rule and append root dynamically to avoid duplicates

## Testing
- `cargo fmt -p llm`
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68bbc3d11b6c832a87b481f54568d5ff