### PR TITLE
refactor(llm): represent assistant messages as part list

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -44,7 +44,7 @@ Trait-based LLM client implementations for multiple providers.
   - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - assistant parts render as individual Harmony messages, emitting thinking before final content when both are present
-  - last assistant parts are tracked and removed from the prompt when forming prefills
+  - the last assistant part is removed from the prompt and used as a prefill when it's text or thinking
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON
   - tool responses map to tool role messages in the commentary channel addressed to the assistant

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -43,6 +43,7 @@ Trait-based LLM client implementations for multiple providers.
   - tool-call rule appended to allow only declared tool names
   - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
+  - assistant parts render as individual Harmony messages, emitting thinking before final content when both are present
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON
   - tool responses map to tool role messages in the commentary channel addressed to the assistant
@@ -55,7 +56,8 @@ Trait-based LLM client implementations for multiple providers.
 - Core message and tool types defined locally instead of re-exporting from `ollama-rs`
   - tool calls hold name and arguments directly and preserve unparseable argument strings
   - tool info stores name, description, and parameters without wrapper enums
-  - chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
+- chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
+    - `AssistantMessage` holds a `Vec<AssistantPart>` for text, tool calls, and thinking segments
     - tool calls include an `id` string, assigned locally when missing
     - tool messages carry the same `id` and store `content` as `serde_json::Value`
 - Chat message, request, and response types serialize to and from JSON

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -44,6 +44,7 @@ Trait-based LLM client implementations for multiple providers.
   - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
   - assistant parts render as individual Harmony messages, emitting thinking before final content when both are present
+  - last assistant parts are tracked and removed from the prompt when forming prefills
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON
   - tool responses map to tool role messages in the commentary channel addressed to the assistant

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -43,7 +43,7 @@ Trait-based LLM client implementations for multiple providers.
   - tool-call rule appended to allow only declared tool names
   - Harmony client builds prompts via helper that handles thinking, final, or both segments when the last history message is from the assistant and emits optional prefills accordingly
   - analysis segments preceding final content are omitted from prompts unless the final message is prefilled
-  - assistant parts render as individual Harmony messages, emitting thinking before final content when both are present
+  - assistant parts render as individual Harmony messages in their original order
   - the last assistant part is removed from the prompt and used as a prefill when it's text or thinking
   - streaming parser is primed with prefill tokens so continuation in the same channel is captured
   - tool calls render in the commentary channel with constrained JSON

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -100,7 +100,11 @@ mod tests {
         let updated = history.lock().unwrap().clone();
         let final_msg = updated.last().unwrap();
         if let ChatMessage::Assistant(a) = final_msg {
-            assert_eq!(a.content, "final");
+            assert_eq!(a.content.len(), 1);
+            match &a.content[0] {
+                crate::AssistantPart::Text { text } => assert_eq!(text, "final"),
+                _ => panic!("expected text part"),
+            }
         } else {
             panic!("expected assistant message");
         }

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use crossterm::event::Event;
 use llm::{
-    ChatMessage, ChatMessageRequest, Provider, ResponseChunk,
+    AssistantPart, ChatMessage, ChatMessageRequest, Provider, ResponseChunk,
     mcp::{McpContext, McpService},
     tools::{ToolEvent, ToolExecutor, tool_event_stream},
 };
@@ -481,9 +481,9 @@ impl Component for App {
                     let mut history = self.chat_history.lock().unwrap();
                     let len_before = history.len();
                     history.retain(|msg| match msg {
-                        ChatMessage::Assistant(a) => {
-                            !(a.content.is_empty() && a.tool_calls.is_empty())
-                        }
+                        ChatMessage::Assistant(a) => a.content.iter().any(|p| {
+                            matches!(p, AssistantPart::Text { .. } | AssistantPart::ToolCall(_))
+                        }),
                         _ => true,
                     });
                     if history.len() != len_before {


### PR DESCRIPTION
## Summary
- refactor assistant messages to store a sequence of parts (text, tool calls, thinking)
- update provider clients and tooling to work with assistant parts
- adjust llment conversation and repair logic for new message structure

## Testing
- `cargo test -p llm`
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68bd29e187b0832ab50e2489c02897a6