### PR TITLE
feat(llm): capture tool errors with JsonResult

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -33,8 +33,7 @@ Trait-based LLM client implementations for multiple providers.
 - LLM clients
 - `LlmClient` trait streams chat responses and lists supported model names
   - implementations for Ollama, OpenAiChat, Harmony, and GeminiRust
-  - GeminiRust function responses place success data under an `output` field
-    - TODO: support the `error` field
+  - GeminiRust function responses place success data under an `output` field and errors under an `error` field
 - Harmony client uses `/completion` with Harmony format for `gpt-oss`
   - sends raw token arrays via `llama_server_completion`
   - sends a GBNF grammar that constrains tool call JSON to each tool's schema
@@ -60,7 +59,7 @@ Trait-based LLM client implementations for multiple providers.
 - chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
     - `AssistantMessage` holds a `Vec<AssistantPart>` for text, tool calls, and thinking segments
     - tool calls include an `id` string, assigned locally when missing
-    - tool messages carry the same `id` and store `content` as `serde_json::Value`
+    - tool messages carry the same `id` and store results via `JsonResult` (`content` or `error`)
 - Chat message, request, and response types serialize to and from JSON
   - skips serializing fields that are `None`, empty strings, or empty arrays
 - Responses

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -33,11 +33,11 @@ impl ChatMessage {
         Self::System(SystemMessage { content })
     }
 
-    pub fn tool(id: String, content: Value, tool_name: String) -> Self {
+    pub fn tool(id: String, content: JsonResult, tool_name: String) -> Self {
         Self::Tool(ToolMessage {
             id,
-            content,
             tool_name,
+            content,
         })
     }
 }
@@ -63,8 +63,25 @@ pub struct SystemMessage {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ToolMessage {
     pub id: String,
-    pub content: Value,
     pub tool_name: String,
+    #[serde(flatten)]
+    pub content: JsonResult,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonResult {
+    Content { content: Value },
+    Error { error: String },
+}
+
+impl JsonResult {
+    pub fn as_result(&self) -> Result<&Value, &str> {
+        match self {
+            JsonResult::Content { content } => Ok(content),
+            JsonResult::Error { error } => Err(error),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -21,7 +21,8 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use super::{
-    AssistantPart, ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
+    AssistantPart, ChatMessage, ChatMessageRequest, ChatStream, JsonResult, LlmClient,
+    ResponseChunk, ToolCall,
 };
 
 pub struct OllamaClient {
@@ -80,8 +81,11 @@ impl LlmClient for OllamaClient {
                     }
                     ChatMessage::Tool(t) => {
                         let content_str = match t.content {
-                            Value::String(s) => s,
-                            v => v.to_string(),
+                            JsonResult::Content { content } => match content {
+                                Value::String(s) => s,
+                                v => v.to_string(),
+                            },
+                            JsonResult::Error { error } => error,
                         };
                         let mut msg = OllamaChatMessage::new(OllamaMessageRole::Tool, content_str);
                         msg.tool_name = Some(t.tool_name);

--- a/crates/llm/src/openai_chat.rs
+++ b/crates/llm/src/openai_chat.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use super::{
-    AssistantPart, ChatMessage, ChatMessageRequest, ChatStream, LlmClient, ResponseChunk, ToolCall,
-    to_openapi_schema,
+    AssistantPart, ChatMessage, ChatMessageRequest, ChatStream, JsonResult, LlmClient,
+    ResponseChunk, ToolCall, to_openapi_schema,
 };
 use async_openai::{Client, config::OpenAIConfig, types::*};
 use async_trait::async_trait;
@@ -131,8 +131,11 @@ impl LlmClient for OpenAiChatClient {
                 }
                 ChatMessage::Tool(t) => {
                     let content_str = match &t.content {
-                        Value::String(s) => s.clone(),
-                        v => v.to_string(),
+                        JsonResult::Content { content } => match content {
+                            Value::String(s) => s.clone(),
+                            v => v.to_string(),
+                        },
+                        JsonResult::Error { error } => error.clone(),
                     };
                     serde_json::to_value(ChatCompletionRequestMessage::Tool(
                         ChatCompletionRequestToolMessageArgs::default()

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -119,6 +119,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - final responses render markdown via termimad
       - streaming updates append thinking text, tool calls, and tool results
       - tool steps display original argument strings when JSON parsing fails
+      - tool steps show tool result or error string from `ToolMessage` `JsonResult`
       - tool steps keyed by the original `ToolCall` id
       - wrapped lines prefix continuation lines with `│`
       - tool step headers show tool name italic and underlined

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{Event, MouseButton, MouseEventKind};
-use llm::{AssistantPart, ChatMessage};
+use llm::{AssistantPart, ChatMessage, JsonResult};
 use ratatui::{Frame, layout::Rect};
 use serde_json::to_string;
 
@@ -328,12 +328,16 @@ impl Conversation {
                     }
                 }
                 ChatMessage::Tool(tmsg) => {
-                    if !self.update_tool_result(&tmsg.id, tmsg.content.to_string(), false) {
+                    let result = match &tmsg.content {
+                        JsonResult::Content { content } => to_string(content).unwrap_or_default(),
+                        JsonResult::Error { error } => error.clone(),
+                    };
+                    if !self.update_tool_result(&tmsg.id, result.clone(), false) {
                         let mut step = ToolStep::new(
                             tmsg.tool_name.clone(),
                             tmsg.id.clone(),
                             String::new(),
-                            tmsg.content.to_string(),
+                            result,
                             false,
                         );
                         step.done = true;


### PR DESCRIPTION
## Summary
- represent tool outputs as `JsonResult` so they can contain content or error
- propagate tool execution errors into chat history
- send tool errors in provider requests (OpenAI, Gemini, Harmony, Ollama)

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68bd7053bb28832a9f5aa2fada104486