### PR TITLE
refactor(llm): store tool call arguments as JsonResult

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -54,7 +54,7 @@ Trait-based LLM client implementations for multiple providers.
 - Tool schemas
   - `to_openapi_schema` strips `$schema` and converts unsigned ints to signed formats
 - Core message and tool types defined locally instead of re-exporting from `ollama-rs`
-  - tool calls hold name and arguments directly and preserve unparseable argument strings
+  - tool calls hold name and arguments via `JsonResult`, preserving unparseable argument strings in the `error` variant
   - tool info stores name, description, and parameters without wrapper enums
 - chat messages are an enum of `UserMessage`, `AssistantMessage`, `SystemMessage`, and `ToolMessage`, each with only relevant fields
     - `AssistantMessage` holds a `Vec<AssistantPart>` for text, tool calls, and thinking segments
@@ -75,7 +75,7 @@ Trait-based LLM client implementations for multiple providers.
   - `tool_event_stream` spawns the loop and yields `ToolEvent`s
     - `RequestStarted` fires when a new request is sent
     - join handle resolves on completion with history updated in place
-    - `ToolStarted` events include original argument strings when parsing fails
+    - `ToolStarted` events carry arguments as `JsonResult` and include original argument strings when parsing fails
     - `ToolStarted` and `ToolResult` keep the original `ToolCall` id
   - tool calls with invalid arguments skip executor invocation and return "Could not parse arguments as JSON"
 - `mcp` module

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -88,9 +88,8 @@ impl JsonResult {
 pub struct ToolCall {
     pub id: String,
     pub name: String,
-    pub arguments: Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments_invalid: Option<String>,
+    #[serde(flatten)]
+    pub arguments: JsonResult,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/llm/src/test_provider.rs
+++ b/crates/llm/src/test_provider.rs
@@ -52,7 +52,7 @@ impl LlmClient for TestProvider {
 mod tests {
     use super::*;
     use crate::tools::{ToolExecutor, run_tool_loop};
-    use crate::{ChatMessage, ToolCall};
+    use crate::{ChatMessage, JsonResult, ToolCall};
     use serde_json::Value;
     use std::sync::{Arc, Mutex};
 
@@ -76,8 +76,9 @@ mod tests {
             ResponseChunk::ToolCall(ToolCall {
                 id: "call-1".into(),
                 name: "test".into(),
-                arguments: Value::Null,
-                arguments_invalid: None,
+                arguments: JsonResult::Content {
+                    content: Value::Null,
+                },
             }),
             ResponseChunk::Done,
         ]);

--- a/crates/llment/src/app.rs
+++ b/crates/llment/src/app.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use crossterm::event::Event;
 use llm::{
-    AssistantPart, ChatMessage, ChatMessageRequest, Provider, ResponseChunk,
+    AssistantPart, ChatMessage, ChatMessageRequest, JsonResult, Provider, ResponseChunk,
     mcp::{McpContext, McpService},
     tools::{ToolEvent, ToolExecutor, tool_event_stream},
 };
@@ -228,11 +228,13 @@ impl App {
                 call_id,
                 name,
                 args,
-                args_invalid,
             } => {
                 self.state = ConversationState::CallingTool(name.clone());
                 let _ = self.model.needs_redraw.send(true);
-                let arg_str = args_invalid.unwrap_or_else(|| args.to_string());
+                let arg_str = match args {
+                    JsonResult::Content { content } => content.to_string(),
+                    JsonResult::Error { error } => error,
+                };
                 self.conversation.add_tool_step(ToolStep::new(
                     name,
                     call_id,

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -313,9 +313,12 @@ impl Conversation {
                                 }
                             }
                             AssistantPart::ToolCall(call) => {
-                                let args = call.arguments_invalid.clone().unwrap_or_else(|| {
-                                    to_string(&call.arguments).unwrap_or_default()
-                                });
+                                let args = match &call.arguments {
+                                    JsonResult::Content { content } => {
+                                        to_string(content).unwrap_or_default()
+                                    }
+                                    JsonResult::Error { error } => error.clone(),
+                                };
                                 self.add_tool_step(ToolStep::new(
                                     call.name.clone(),
                                     call.id.clone(),


### PR DESCRIPTION
## Summary
- replace ToolCall argument fields with flattened JsonResult
- propagate JsonResult through tool events, clients, and UI

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be229c712c832aa500490e236e9b08