### PR TITLE
feat(llment): add thought and response commands

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -55,7 +55,7 @@ Basic terminal chat interface scaffold using a bespoke component framework built
     - clicking the field focuses it
     - cursor hidden when unfocused
     - recognizes `/` commands
-      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/save`, `/load`, `/model`, `/provider`, `/prompt`, `/role`, and `/agent-mode`
+      - `/` opens a popup with `/quit`, `/clear`, `/redo`, `/repair`, `/continue`, `/thought`, `/response`, `/save`, `/load`, `/model`, `/provider`, `/prompt`, `/role`, and `/agent-mode`
         - width adjusts to content
         - `Up`/`Down` navigate selection
         - `Tab` completes and `Enter` executes

--- a/crates/llment/src/commands/mod.rs
+++ b/crates/llment/src/commands/mod.rs
@@ -8,8 +8,10 @@ pub mod provider;
 pub mod quit;
 pub mod redo;
 pub mod repair;
+pub mod response;
 pub mod role;
 pub mod save;
+pub mod thought;
 
 pub use agent_mode::AgentModeCommand;
 pub use clear::ClearCommand;
@@ -21,5 +23,7 @@ pub use provider::ProviderCommand;
 pub use quit::QuitCommand;
 pub use redo::RedoCommand;
 pub use repair::RepairCommand;
+pub use response::ResponseCommand;
 pub use role::RoleCommand;
 pub use save::SaveCommand;
+pub use thought::ThoughtCommand;

--- a/crates/llment/src/commands/response.rs
+++ b/crates/llment/src/commands/response.rs
@@ -1,0 +1,54 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct ResponseCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for ResponseCommand {
+    fn name(&self) -> &'static str {
+        "response"
+    }
+    fn description(&self) -> &'static str {
+        "Append a response message to the conversation"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ResponseCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+            param: String::new(),
+        })
+    }
+}
+
+struct ResponseCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+    param: String,
+}
+
+impl CommandInstance for ResponseCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        self.param = input.to_string();
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+
+    fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self
+            .update_tx
+            .send(Update::AppendResponse(self.param.clone()));
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/commands/thought.rs
+++ b/crates/llment/src/commands/thought.rs
@@ -1,0 +1,54 @@
+use tokio::sync::{mpsc::UnboundedSender, watch};
+
+use crate::{
+    app::Update,
+    components::completion::{Command, CommandInstance, CompletionResult},
+};
+
+pub struct ThoughtCommand {
+    pub(crate) needs_update: watch::Sender<bool>,
+    pub(crate) update_tx: UnboundedSender<Update>,
+}
+
+impl Command for ThoughtCommand {
+    fn name(&self) -> &'static str {
+        "thought"
+    }
+    fn description(&self) -> &'static str {
+        "Append a thinking message to the conversation"
+    }
+    fn has_params(&self) -> bool {
+        true
+    }
+    fn instance(&self) -> Box<dyn CommandInstance> {
+        Box::new(ThoughtCommandInstance {
+            needs_update: self.needs_update.clone(),
+            update_tx: self.update_tx.clone(),
+            param: String::new(),
+        })
+    }
+}
+
+struct ThoughtCommandInstance {
+    needs_update: watch::Sender<bool>,
+    update_tx: UnboundedSender<Update>,
+    param: String,
+}
+
+impl CommandInstance for ThoughtCommandInstance {
+    fn update(&mut self, input: &str) -> CompletionResult {
+        self.param = input.to_string();
+        CompletionResult::Options {
+            at: 0,
+            options: vec![],
+        }
+    }
+
+    fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self
+            .update_tx
+            .send(Update::AppendThought(self.param.clone()));
+        let _ = self.needs_update.send(true);
+        Ok(())
+    }
+}

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -184,6 +184,17 @@ impl Conversation {
         }
     }
 
+    pub fn push_assistant(&mut self) {
+        self.items.push(Node::Assistant(AssistantBlock::new(
+            false,
+            Vec::new(),
+            String::new(),
+        )));
+        self.needs_layout = true;
+        self.ensure_layout(self.width);
+        self.scroll_to_bottom();
+    }
+
     pub fn push_user(&mut self, text: String) {
         self.items.push(Node::User(UserBubble::new(text)));
         self.needs_layout = true;


### PR DESCRIPTION
## Summary
- add `/thought` and `/response` commands for manually adding assistant messages
- document new commands in AGENTS

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68c0d7bf3a4c832aa08fcc27f560275d