### PR TITLE
fix(llm): handle MCP tool execution errors

### DIFF
--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -90,6 +90,7 @@ Trait-based LLM client implementations for multiple providers.
     - provides a non-blocking `tool_names` snapshot of available tools
     - implements `ToolExecutor` for MCP calls
       - unrecognized or unprefixed tool names return "{name} is not a valid tool name"
+      - tool execution errors with `is_error` set propagate as `Err`
     - tool call chunks insert assistant messages immediately before execution
       - accumulated assistant content is flushed as a separate assistant message
       - the tool-call assistant message carries empty `content` with `tool_calls` populated

--- a/crates/llm/src/mcp.rs
+++ b/crates/llm/src/mcp.rs
@@ -116,21 +116,25 @@ impl ToolExecutor for McpContext {
                 arguments: args.as_object().cloned(),
             })
             .await?;
-
-        if let Some(content) = result.content {
-            let text = content
+        let text = if let Some(content) = result.content {
+            content
                 .into_iter()
                 .filter_map(|c| match c.raw {
                     RawContent::Text(t) => Some(t.text),
                     _ => None,
                 })
                 .collect::<Vec<_>>()
-                .join("\n");
-            Ok(text)
+                .join("\n")
         } else if let Some(value) = result.structured_content {
-            Ok(value.to_string())
+            value.to_string()
         } else {
-            Ok(String::new())
+            String::new()
+        };
+
+        if result.is_error.unwrap_or(false) {
+            Err(text.into())
+        } else {
+            Ok(text)
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate MCP tool execution errors from `McpContext::call`
- document MCP error propagation in llm AGENTS

## Testing
- `cargo test -p llm`


------
https://chatgpt.com/codex/tasks/task_e_68c125cf498c832a99f2ef8f6d9614f0