### PR TITLE
Use tool execution errors in mcp-edit and mcp-shell

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -47,6 +47,8 @@ MCP server offering file system editing utilities.
 - parameter metadata
   - tool parameters include descriptions and default values via rmcp
   - optional parameters prefix descriptions with "Optional."
+- tool errors reported via `CallToolResult::error`
+  - operations return execution errors instead of protocol errors
 
 ## Constraints
 - paths outside the workspace return the same error regardless of file existence

--- a/crates/mcp-shell/AGENTS.md
+++ b/crates/mcp-shell/AGENTS.md
@@ -36,6 +36,8 @@ MCP server exposing shell command execution.
 - parameter metadata
   - tool parameters include descriptions and default values via rmcp
   - optional parameters prefix descriptions with "Optional."
+- tool errors reported via `CallToolResult::error`
+  - state issues like missing or running commands return execution errors
 
 ## Constraints
 - working directory must already exist; it is not created automatically


### PR DESCRIPTION
## Summary
- return tool execution errors from mcp-edit operations
- surface shell errors as CallToolResult::error

## Testing
- `cargo test -p mcp-edit`
- `cargo test -p mcp-shell`


------
https://chatgpt.com/codex/tasks/task_e_68c13924190c832a97e6791dba9f1a33