### PR TITLE
refactor(llment): centralize history edits via callbacks

### DIFF
--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -104,6 +104,9 @@ Basic terminal chat interface scaffold using a bespoke component framework built
       - command commit behavior
         - on successful commit, the router clears the active command instance
         - on commit error, the active command instance remains for user correction
+      - history edits handled through `Update::EditHistory` callbacks from `history_edits.rs`
+        - callbacks mutate chat history directly and return results with optional prompt text
+        - result flags can abort in-flight requests or reset session token counters
   - dismissable error box above the input with an X button displays request errors
   - Esc exits the application
   - 1-line status area

--- a/crates/llment/src/commands/clear.rs
+++ b/crates/llment/src/commands/clear.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct ClearCommand {
@@ -38,7 +39,9 @@ impl CommandInstance for ClearCommandInstance {
         }
     }
     fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self.update_tx.send(Update::Clear);
+        let _ = self
+            .update_tx
+            .send(Update::EditHistory(history_edits::clear()));
         let _ = self.needs_update.send(true);
         Ok(())
     }

--- a/crates/llment/src/commands/load.rs
+++ b/crates/llment/src/commands/load.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct LoadCommand {
@@ -48,7 +49,8 @@ impl CommandInstance for LoadCommandInstance {
         if self.param.is_empty() {
             Err("no filename".into())
         } else {
-            let _ = self.update_tx.send(Update::Load(self.param.clone()));
+            let edit = history_edits::load(self.param.clone());
+            let _ = self.update_tx.send(Update::EditHistory(edit));
             let _ = self.needs_update.send(true);
             Ok(())
         }

--- a/crates/llment/src/commands/pop.rs
+++ b/crates/llment/src/commands/pop.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct PopCommand {
@@ -38,7 +39,9 @@ impl CommandInstance for PopCommandInstance {
         }
     }
     fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self.update_tx.send(Update::Pop);
+        let _ = self
+            .update_tx
+            .send(Update::EditHistory(history_edits::pop()));
         let _ = self.needs_update.send(true);
         Ok(())
     }

--- a/crates/llment/src/commands/redo.rs
+++ b/crates/llment/src/commands/redo.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct RedoCommand {
@@ -38,7 +39,9 @@ impl CommandInstance for RedoCommandInstance {
         }
     }
     fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self.update_tx.send(Update::Redo);
+        let _ = self
+            .update_tx
+            .send(Update::EditHistory(history_edits::redo()));
         let _ = self.needs_update.send(true);
         Ok(())
     }

--- a/crates/llment/src/commands/response.rs
+++ b/crates/llment/src/commands/response.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct ResponseCommand {
@@ -45,9 +46,8 @@ impl CommandInstance for ResponseCommandInstance {
     }
 
     fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self
-            .update_tx
-            .send(Update::AppendResponse(self.param.clone()));
+        let edit = history_edits::append_response(self.param.clone());
+        let _ = self.update_tx.send(Update::EditHistory(edit));
         let _ = self.needs_update.send(true);
         Ok(())
     }

--- a/crates/llment/src/commands/save.rs
+++ b/crates/llment/src/commands/save.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct SaveCommand {
@@ -48,7 +49,8 @@ impl CommandInstance for SaveCommandInstance {
         if self.param.is_empty() {
             Err("no filename".into())
         } else {
-            let _ = self.update_tx.send(Update::Save(self.param.clone()));
+            let edit = history_edits::save(self.param.clone());
+            let _ = self.update_tx.send(Update::EditHistory(edit));
             let _ = self.needs_update.send(true);
             Ok(())
         }

--- a/crates/llment/src/commands/thought.rs
+++ b/crates/llment/src/commands/thought.rs
@@ -3,6 +3,7 @@ use tokio::sync::{mpsc::UnboundedSender, watch};
 use crate::{
     app::Update,
     components::completion::{Command, CommandInstance, CompletionResult},
+    history_edits,
 };
 
 pub struct ThoughtCommand {
@@ -45,9 +46,8 @@ impl CommandInstance for ThoughtCommandInstance {
     }
 
     fn commit(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self
-            .update_tx
-            .send(Update::AppendThought(self.param.clone()));
+        let edit = history_edits::append_thought(self.param.clone());
+        let _ = self.update_tx.send(Update::EditHistory(edit));
         let _ = self.needs_update.send(true);
         Ok(())
     }

--- a/crates/llment/src/conversation/conversation.rs
+++ b/crates/llment/src/conversation/conversation.rs
@@ -280,18 +280,6 @@ impl Conversation {
         }
     }
 
-    pub fn redo_last(&mut self) -> Option<String> {
-        while !self.items.is_empty() {
-            if let Some(Node::User(user)) = self.items.pop() {
-                self.needs_layout = true;
-                self.ensure_layout(self.width);
-                self.scroll_to_bottom();
-                return Some(user.text);
-            }
-        }
-        None
-    }
-
     pub fn set_history(&mut self, history: &[ChatMessage]) {
         self.clear();
         for msg in history {

--- a/crates/llment/src/history_edits.rs
+++ b/crates/llment/src/history_edits.rs
@@ -1,0 +1,110 @@
+use llm::{AssistantPart, ChatMessage};
+
+/// Result of applying a history edit.
+#[derive(Default)]
+pub struct HistoryEditResult {
+    /// Optional prompt text to set in the input.
+    pub prompt: Option<String>,
+    /// Whether session token counters should be reset.
+    pub reset_session: bool,
+    /// Whether any in-flight requests should be aborted.
+    pub abort_requests: bool,
+}
+
+/// Callback mutating chat history and returning a `HistoryEditResult` or error string.
+pub type HistoryEdit =
+    Box<dyn FnOnce(&mut Vec<ChatMessage>) -> Result<HistoryEditResult, String> + Send>;
+
+pub fn append_thought(text: String) -> HistoryEdit {
+    Box::new(move |history: &mut Vec<ChatMessage>| {
+        history.push(ChatMessage::Assistant(llm::AssistantMessage {
+            content: vec![AssistantPart::Thinking { text: text.clone() }],
+        }));
+        Ok(HistoryEditResult::default())
+    })
+}
+
+pub fn append_response(text: String) -> HistoryEdit {
+    Box::new(move |history: &mut Vec<ChatMessage>| {
+        let append = matches!(history.last(), Some(ChatMessage::Assistant(a)) if !a
+            .content
+            .iter()
+            .any(|p| matches!(p, AssistantPart::Text { .. } | AssistantPart::ToolCall(_))));
+        if append {
+            if let Some(ChatMessage::Assistant(a)) = history.last_mut() {
+                a.content.push(AssistantPart::Text { text: text.clone() });
+            }
+        } else {
+            history.push(ChatMessage::assistant(text.clone()));
+        }
+        Ok(HistoryEditResult::default())
+    })
+}
+
+pub fn pop() -> HistoryEdit {
+    Box::new(|history: &mut Vec<ChatMessage>| {
+        let mut removed = false;
+        if let Some(ChatMessage::Assistant(a)) = history.last_mut() {
+            if a.content.pop().is_some() {
+                removed = true;
+                if a.content.is_empty() {
+                    history.pop();
+                }
+            }
+        }
+        if !removed {
+            history.pop();
+        }
+        Ok(HistoryEditResult::default())
+    })
+}
+
+pub fn clear() -> HistoryEdit {
+    Box::new(|history: &mut Vec<ChatMessage>| {
+        history.clear();
+        Ok(HistoryEditResult {
+            reset_session: true,
+            abort_requests: true,
+            ..HistoryEditResult::default()
+        })
+    })
+}
+
+pub fn redo() -> HistoryEdit {
+    Box::new(|history: &mut Vec<ChatMessage>| {
+        let mut prompt = None;
+        while let Some(msg) = history.pop() {
+            if let ChatMessage::User(u) = msg {
+                prompt = Some(u.content);
+                break;
+            }
+        }
+        Ok(HistoryEditResult {
+            prompt,
+            abort_requests: true,
+            ..HistoryEditResult::default()
+        })
+    })
+}
+
+pub fn save(path: String) -> HistoryEdit {
+    Box::new(move |history: &mut Vec<ChatMessage>| {
+        let data = serde_json::to_string_pretty(&*history).unwrap();
+        std::fs::write(&path, data).map_err(|e| format!("failed to save: {}", e))?;
+        Ok(HistoryEditResult::default())
+    })
+}
+
+pub fn load(path: String) -> HistoryEdit {
+    Box::new(move |history: &mut Vec<ChatMessage>| {
+        let data = std::fs::read_to_string(&path).map_err(|e| format!("failed to load: {}", e))?;
+        let loaded: Vec<ChatMessage> =
+            serde_json::from_str(&data).map_err(|e| format!("failed to parse: {}", e))?;
+        *history = loaded;
+        Ok(HistoryEditResult {
+            reset_session: true,
+            abort_requests: true,
+            ..HistoryEditResult::default()
+        })
+    })
+}

--- a/crates/llment/src/main.rs
+++ b/crates/llment/src/main.rs
@@ -27,6 +27,7 @@ mod commands;
 mod component;
 mod components;
 mod conversation;
+mod history_edits;
 mod markdown;
 mod modes;
 mod prompts;


### PR DESCRIPTION
## Summary
- rework history edit callbacks to mutate history and return results with optional prompt and session flags
- update app to apply edit results without exposing internal state
- document history edit result behavior in AGENTS

## Testing
- `cargo test -p llment`


------
https://chatgpt.com/codex/tasks/task_e_68c142fd1714832a8750a0c5876ce0c4