### PR TITLE
feat: annotate MCP tools with read-only hints

### DIFF
--- a/crates/mcp-edit/AGENTS.md
+++ b/crates/mcp-edit/AGENTS.md
@@ -45,6 +45,7 @@ MCP server offering file system editing utilities.
   - `search_file_content`
     - uses `grep` crate for regex searches with optional include filters
     - respects git ignore
+  - read-only tools annotate with `readOnlyHint`: `list_directory`, `read_file`, `read_many_files`, `glob`, `search_file_content`
 - parameter metadata
   - tool parameters include descriptions and default values via rmcp
   - optional parameters prefix descriptions with "Optional."

--- a/crates/mcp-edit/src/lib.rs
+++ b/crates/mcp-edit/src/lib.rs
@@ -279,7 +279,10 @@ impl FsServer {
         )]))
     }
 
-    #[tool(description = "List the contents of a directory.")]
+    #[tool(
+        description = "List the contents of a directory.",
+        annotations(read_only_hint = true)
+    )]
     pub async fn list_directory(
         &self,
         Parameters(params): Parameters<ListDirectoryParams>,
@@ -354,7 +357,7 @@ impl FsServer {
         Ok(CallToolResult::success(vec![Content::text(output)]))
     }
 
-    #[tool(description = "Read a file.")]
+    #[tool(description = "Read a file.", annotations(read_only_hint = true))]
     pub async fn read_file(
         &self,
         Parameters(params): Parameters<ReadFileParams>,
@@ -429,7 +432,10 @@ impl FsServer {
         }
     }
 
-    #[tool(description = "Read multiple files and concatenate their contents.")]
+    #[tool(
+        description = "Read multiple files and concatenate their contents.",
+        annotations(read_only_hint = true)
+    )]
     pub async fn read_many_files(
         &self,
         Parameters(params): Parameters<ReadManyFilesParams>,
@@ -645,7 +651,10 @@ impl FsServer {
         ))]))
     }
 
-    #[tool(description = "Find files matching a glob pattern.")]
+    #[tool(
+        description = "Find files matching a glob pattern.",
+        annotations(read_only_hint = true)
+    )]
     pub async fn glob(
         &self,
         Parameters(params): Parameters<GlobParams>,
@@ -716,7 +725,10 @@ impl FsServer {
         Ok(CallToolResult::success(vec![Content::text(output)]))
     }
 
-    #[tool(description = "Search for a regex pattern in files within a directory.")]
+    #[tool(
+        description = "Search for a regex pattern in files within a directory.",
+        annotations(read_only_hint = true)
+    )]
     pub async fn search_file_content(
         &self,
         Parameters(params): Parameters<SearchFileContentParams>,

--- a/crates/mcp-hello/AGENTS.md
+++ b/crates/mcp-hello/AGENTS.md
@@ -14,6 +14,7 @@ Simple MCP server that provides a greeting tool.
 - tools
   - `hello`
     - returns "Hello, world!"
+    - annotated with `readOnlyHint`
 - server
   - runs over stdio
   - includes tools capability in MCP initialize response

--- a/crates/mcp-hello/src/lib.rs
+++ b/crates/mcp-hello/src/lib.rs
@@ -18,7 +18,10 @@ impl HelloServer {
         }
     }
 
-    #[tool(description = "Return a friendly greeting")]
+    #[tool(
+        description = "Return a friendly greeting",
+        annotations(read_only_hint = true)
+    )]
     pub async fn hello(&self) -> Result<CallToolResult, McpError> {
         Ok(CallToolResult::success(vec![Content::text(
             "Hello, world!",


### PR DESCRIPTION
## Summary
- mark read-only tools in mcp-edit with `readOnlyHint`
- annotate mcp-hello's greeting tool as read-only
- document read-only annotations in crate AGENTS files

## Testing
- `cargo fmt`
- `cargo test -p mcp-edit -p mcp-hello`


------
https://chatgpt.com/codex/tasks/task_e_68c254a80a80832abc74040185340087