### PR TITLE
fix: rename MCP tool names to underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run with defaults (preferred):
 `--mcp file.json` loads a claude-code like mcp.json file.
 
 For example, the following configuration loads two STDIO based MCP servers.
-The functions from `mcp-edit` will be prefixed with `files.` as in `files.create_file`, similarly with `shell.` for `mcp-shell`.
+The functions from `mcp-edit` will be prefixed with `files_` as in `files_create_file`, similarly with `shell_` for `mcp-shell`.
 The server commands are launched with the same working directory that `llment` was.
 
 ```json

--- a/crates/llm/AGENTS.md
+++ b/crates/llm/AGENTS.md
@@ -82,7 +82,7 @@ Trait-based LLM client implementations for multiple providers.
   - tool calls with invalid arguments skip executor invocation and return "Could not parse arguments as JSON"
 - `mcp` module
 - `load_mcp_servers` starts configured MCP servers and collects tool schemas
-  - tool names are prefixed with the server name
+  - tool names are prefixed with the server name, joined with an underscore
   - `McpService` implements `ClientHandler`
     - `on_tool_list_changed` refreshes tool metadata from the service
     - tool metadata stored in an `ArcSwap` for lock-free snapshots

--- a/crates/llm/src/mcp.rs
+++ b/crates/llm/src/mcp.rs
@@ -70,7 +70,7 @@ impl McpContext {
             let tools = svc.service().tools.load();
             for tool in tools.iter() {
                 infos.push(ToolInfo {
-                    name: format!("{}.{}", prefix, tool.name),
+                    name: format!("{}_{}", prefix, tool.name),
                     description: tool.description.clone(),
                     parameters: tool.parameters.clone(),
                 });
@@ -86,7 +86,7 @@ impl McpContext {
             let prefix = svc.service().prefix.clone();
             let tools = svc.service().tools.load();
             for tool in tools.iter() {
-                names.push(format!("{}.{}", prefix, tool.name));
+                names.push(format!("{}_{}", prefix, tool.name));
             }
         }
         names
@@ -101,7 +101,7 @@ impl ToolExecutor for McpContext {
         args: Value,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let (prefix, tool_name) = name
-            .split_once('.')
+            .split_once('_')
             .ok_or_else(|| format!("{name} is not a valid tool name"))?;
         let peer = {
             let services = self.services.lock().unwrap();

--- a/crates/llment/AGENTS.md
+++ b/crates/llment/AGENTS.md
@@ -98,8 +98,8 @@ Basic terminal chat interface scaffold using a bespoke component framework built
         - agent mode `step` can signal `stop` to exit the mode
         - agent modes may adjust or clear the role between steps
         - agent modes may register an MCP service under the `agent` prefix that is added on start and removed when switching modes or when the mode stops
-        - available modes include `code-agent` coordinating director, design-lead, execution-lead, eng-team, and reviewer roles via an `agent.notify` MCP tool
-          - `agent.notify` accepts `role` values of `director`, `design-lead`, `execution-lead`, `eng-team`, or `reviewer`
+        - available modes include `code-agent` coordinating director, design-lead, execution-lead, eng-team, and reviewer roles via an `agent_notify` MCP tool
+          - `agent_notify` accepts `role` values of `director`, `design-lead`, `execution-lead`, `eng-team`, or `reviewer`
         - `/agent-mode off` exits the active agent mode
       - command commit behavior
         - on successful commit, the router clears the active command instance
@@ -164,8 +164,8 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 - Built-in tools registered via `setup_builtin_tools`
   - `setup_builtin_tools` returns a running `McpService` inserted into the shared `McpContext`
   - Tools:
-    - `chat.get_message_count`: returns the number of chat messages
-    - `chat.discard_function_response`:
+    - `chat_get_message_count`: returns the number of chat messages
+    - `chat_discard_function_response`:
       - parameters: `{ id: string }`
       - finds a `Tool` message by matching `id` and clears its result text
       - returns `"ok"` on success or a not-found message if no matching entry exists
@@ -179,4 +179,4 @@ Basic terminal chat interface scaffold using a bespoke component framework built
 - switching model aborts in-flight requests without clearing history or resetting token counters
 - partial items are clipped when scrolled
 - collapsed content does not contribute to layout height
-- MCP tool names are prefixed with the server name; built-in tools use the `chat` prefix, agent mode tools use the `agent` prefix
+- MCP tool names are prefixed with the server name, joined with an underscore; built-in tools use the `chat` prefix, agent mode tools use the `agent` prefix

--- a/crates/llment/prompts/roles/code-agent/design-lead.md
+++ b/crates/llment/prompts/roles/code-agent/design-lead.md
@@ -18,5 +18,5 @@ Do not modify any other files in the workspace, leave that to the team.
 
 When you are finished:
 1. use git to commit your changes, make sure the working directory is clean before continuing
-2. call agent.notify for role `execution-lead`
+2. call agent_notify for role `execution-lead`
 3. stop

--- a/crates/llment/prompts/roles/code-agent/director.md
+++ b/crates/llment/prompts/roles/code-agent/director.md
@@ -1,7 +1,7 @@
 Analyze the content of the workspace.
 
-If there exists a top-level `task.md` file, then call agent.notify for role `eng-team`, ask them to resume their work, and stop.
+If there exists a top-level `task.md` file, then call agent_notify for role `eng-team`, ask them to resume their work, and stop.
 
-If there is already a top-level `objective.md` file, then call agent.notify for role `design-lead` and stop.
+If there is already a top-level `objective.md` file, then call agent_notify for role `design-lead` and stop.
 
-Otherwise, discuss with the user what the objective should be; once you have enough information, after confirming with the user, write the objective to the top-level `objective.md`, use git to commit the change, and then call agent.notify for role `design-lead` and stop.
+Otherwise, discuss with the user what the objective should be; once you have enough information, after confirming with the user, write the objective to the top-level `objective.md`, use git to commit the change, and then call agent_notify for role `design-lead` and stop.

--- a/crates/llment/prompts/roles/code-agent/eng-team.md
+++ b/crates/llment/prompts/roles/code-agent/eng-team.md
@@ -22,5 +22,5 @@ Begin work on the task.
 When you are completely finished with the task:
 1. ensure the task log is up to date - did you complete all the TODOs?
 2. use git to commit your changes, make sure the working directory is clean before continuing (git status)
-3. call agent.notify for role `reviewer` summarizing any deviations from the task
+3. call agent_notify for role `reviewer` summarizing any deviations from the task
 4. stop

--- a/crates/llment/prompts/roles/code-agent/execution-lead.md
+++ b/crates/llment/prompts/roles/code-agent/execution-lead.md
@@ -22,5 +22,5 @@ Do not modify any other files in the workspace, leave that to the eng team.
 
 When you are finished:
 1. use git to commit your changes, make sure the working directory is clean (git status) before continuing
-2. call agent.notify for role `eng-team`
+2. call agent_notify for role `eng-team`
 3. stop

--- a/crates/llment/prompts/roles/code-agent/reviewer.md
+++ b/crates/llment/prompts/roles/code-agent/reviewer.md
@@ -19,7 +19,7 @@ Do not rely on or trust the task log or the message from the team. Verify the ch
 
 Do not modify the code, if there are problems the eng-team will fix them.
 
-If the working directory is dirty or there are problems call agent.notify for role `eng-team`, and summarize any problems or changes that are necessary, and stop.
+If the working directory is dirty or there are problems call agent_notify for role `eng-team`, and summarize any problems or changes that are necessary, and stop.
 
-Otherwise, only if the work is satisfactory, call agent.notify for role `execution-lead`, and request that they assign the next task; if there are any deviations from the task, summarize them, and stop.
+Otherwise, only if the work is satisfactory, call agent_notify for role `execution-lead`, and request that they assign the next task; if there are any deviations from the task, summarize them, and stop.
 

--- a/crates/llment/prompts/snippets/env/workspace.md
+++ b/crates/llment/prompts/snippets/env/workspace.md
@@ -1,6 +1,6 @@
 # Workspace Overview
 
-All commands, {% if tool_enabled("shell.run") %}shell interactions, {% endif %}and tools executed in this environment are performed **relative to the workspace root** by default:
+All commands, {% if tool_enabled("shell_run") %}shell interactions, {% endif %}and tools executed in this environment are performed **relative to the workspace root** by default:
 
 ```
 /home/user/workspace

--- a/crates/llment/prompts/snippets/instructions/context.md
+++ b/crates/llment/prompts/snippets/instructions/context.md
@@ -1,10 +1,9 @@
-{% if tool_enabled("chat.discard_function_response") %}
+{% if tool_enabled("chat_discard_function_response") %}
 ## Context
 
 In this environment there is limited history and context size available.
 
-It's important that you remove function responses (FR) that are no longer necessary by calling the chat.
-discard_function_response.
+It's important that you remove function responses (FR) that are no longer necessary by calling the `chat_discard_function_response` tool.
 
 Summarize the necessary parts of the FR with chain-of-thought, then proactively discard the FR as soon as possible -- before proceeding with other function calls. If the contents of the FR needs to be part of a message to the user, wait for a subsequent round before discarding.
 

--- a/crates/llment/prompts/snippets/shell/apply_patch.md
+++ b/crates/llment/prompts/snippets/shell/apply_patch.md
@@ -1,4 +1,4 @@
-{% if tool_enabled("shell.run") %}
+{% if tool_enabled("shell_run") %}
 You have access to the `apply_patch` shell command to edit files. Follow these rules exactly.
 
 **Contract**

--- a/crates/llment/prompts/snippets/shell/ls.md
+++ b/crates/llment/prompts/snippets/shell/ls.md
@@ -1,4 +1,4 @@
-{% if tool_enabled("shell.run") %}
+{% if tool_enabled("shell_run") %}
 ## Searching and Listing Files
 
 Use `rg` -- ripgrep. Always use `rg` instead of `grep`.

--- a/crates/llment/prompts/snippets/shell/timeout.md
+++ b/crates/llment/prompts/snippets/shell/timeout.md
@@ -1,7 +1,7 @@
-{% if tool_enabled("shell.wait") %}
+{% if tool_enabled("shell_wait") %}
 # Timeout Handling for Shell Commands
 
-When a command launched via `shell.run` exceeds the allotted time, the
+When a command launched via `shell_run` exceeds the allotted time, the
 operation may either still be making progress or be stalled.  You
 should decide whether to continue waiting for a normal exit or to
 terminate the process.
@@ -12,9 +12,9 @@ terminate the process.
    command times out.
 2. **Check for ongoing progress** – If the command is still producing
    output (stdout/stderr) or updating its internal state, it is likely
-   alive.  In this case, call `shell.wait` to allow the process to
+   alive.  In this case, call `shell_wait` to allow the process to
    continue.
 3. **Abort if stalled** – If the command shows no output for a period
-   or appears stuck, call `shell.terminate`.
+   or appears stuck, call `shell_terminate`.
 {% endif %}
 

--- a/crates/llment/src/modes/code_agent.rs
+++ b/crates/llment/src/modes/code_agent.rs
@@ -164,7 +164,7 @@ impl AgentMode for CodeAgentMode {
             AgentModeStep {
                 role: Some(format!("code-agent/{}", self.current_role.as_str())),
                 prompt: Some(
-                    "Please finish your job and then call agent.notify(role, message) as requested.".to_string(),
+                    "Please finish your job and then call agent_notify(role, message) as requested.".to_string(),
                 ),
                 clear_history: false,
                 stop: false,

--- a/crates/llment/src/prompts.rs
+++ b/crates/llment/src/prompts.rs
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn tool_enabled_fn() {
-        let content = load_prompt("tool", None, vec!["shell.run".to_string()], None).unwrap();
+        let content = load_prompt("tool", None, vec!["shell_run".to_string()], None).unwrap();
         assert!(content.contains("Enabled!"));
         let content = load_prompt("tool", None, Vec::new(), None).unwrap();
         assert!(content.contains("Disabled!"));

--- a/crates/llment/tests/prompts/system/tool.md
+++ b/crates/llment/tests/prompts/system/tool.md
@@ -1,4 +1,4 @@
-{% if tool_enabled("shell.run") %}
+{% if tool_enabled("shell_run") %}
 Enabled!
 {% else %}
 Disabled!


### PR DESCRIPTION
## Summary
- format MCP context tool metadata using underscore-separated names and adjust execution parsing
- update prompts, tests, and code agent instructions to reference the new MCP tool identifiers
- refresh README and AGENTS docs to describe the underscore-prefixed tool naming scheme

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c9323d5aa8832abe8727b27dc46cf2